### PR TITLE
🧹 [Code Health] Improve error handling for missing backup paths

### DIFF
--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -10,8 +10,14 @@ use arq::folder::{Folder, FolderData};
 use arq::object_encryption;
 
 pub fn get_latest_folder_data_path(path: &Path) -> Result<PathBuf> {
+    if !path.exists() {
+        return Err(crate::error::Error::NotFound(format!(
+            "Backup path does not exist: {}",
+            path.display()
+        )));
+    }
+
     let mut newest = "0".to_string();
-    // TODO(nlopes): what if the path doesn't exist? Provide nicer output.
     for entry in std::fs::read_dir(path)? {
         let filename = entry?.file_name().to_str().unwrap().to_string();
         if filename > newest {


### PR DESCRIPTION
🎯 **What:** Added a check for `!path.exists()` in `get_latest_folder_data_path` to return a clear custom error instead of failing opaquely when a backup path doesn't exist.
💡 **Why:** This makes the codebase more robust and helps diagnose issues quickly by returning an understandable error. It addresses a pre-existing TODO.
✅ **Verification:** Ran `cargo test` and ensured all tests passed successfully.
✨ **Result:** Improved maintainability and user experience by providing a descriptive error message when dealing with invalid paths.

---
*PR created automatically by Jules for task [11972730491793286699](https://jules.google.com/task/11972730491793286699) started by @ljen*