### PR TITLE
🔒 fix: prevent panic on non-UTF8 filenames in recovery

### DIFF
--- a/evu/src/recovery.rs
+++ b/evu/src/recovery.rs
@@ -52,7 +52,7 @@ fn restore_file_in_tree(
     for (name, node) in tree.nodes {
         if !node.is_tree {
             let inner = prefix.join(name);
-            if inner.as_os_str().to_str().unwrap() == absolute_filepath {
+            if inner.as_os_str().to_str().unwrap_or("") == absolute_filepath {
                 restore_object(path, folder, &node, absolute_filepath, &keyset.encryption_key)?;
                 // Passed node as reference
             }
@@ -98,7 +98,7 @@ fn restore_object(
 
     for blob in &node.data_blob_locs { // Iterate over a reference to avoid moving
         for entry in std::fs::read_dir(&path)? {
-            let fname = entry?.file_name().to_str().unwrap().to_string();
+            let fname = entry?.file_name().to_string_lossy().to_string();
             if fname.ends_with(".index") {
                 let index_path = path.join(&fname);
                 let mut reader = utils::get_file_reader(index_path);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a panic caused by unwrapping the result of converting an `OsStr` filename to a UTF-8 string when the filename contains invalid UTF-8 characters.
⚠️ **Risk:** An attacker could craft a malicious backup or directory containing non-UTF8 filenames. When the recovery mechanism parses this, the process would panic, leading to a Denial of Service (DoS) vulnerability.
🛡️ **Solution:** The fix replaces `.unwrap()` with `.unwrap_or("")` when comparing paths, and uses `.to_string_lossy()` when collecting filenames from a directory. This safely handles invalid UTF-8 sequences without crashing the application.

---
*PR created automatically by Jules for task [4421371465143317918](https://jules.google.com/task/4421371465143317918) started by @ljen*