### PR TITLE
🧪 [testing improvement] Add error handling test for get_computers

### DIFF
--- a/evu/src/computers.rs
+++ b/evu/src/computers.rs
@@ -25,3 +25,14 @@ pub fn show(path: &str) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_computers_invalid_path() {
+        let result = get_computers("/nonexistent/path/that/should/fail");
+        assert!(result.is_err(), "Expected an error for an invalid path");
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added an error handling test for `get_computers` to verify that an invalid path returns an error.
📊 **Coverage:** The test covers the scenario where the path passed to `get_computers` does not exist.
✨ **Result:** Increased test coverage for error conditions in `evu/src/computers.rs`.

---
*PR created automatically by Jules for task [18134945819337053690](https://jules.google.com/task/18134945819337053690) started by @ljen*