### PR TITLE
🧪 Add test for `is_debug_enabled`

### DIFF
--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -88,3 +88,14 @@ macro_rules! debug_eprintln {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_debug_enabled_default() {
+        // By default, the IS_DEBUG atomic bool should be initialized to false.
+        assert_eq!(is_debug_enabled(), false);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a unit test for `is_debug_enabled` in `evu/src/utils.rs` which was previously untested.
📊 **Coverage:** The new test verifies the default state of the `is_debug_enabled` function.
✨ **Result:** Improved test coverage for `evu/src/utils.rs` by adding a test for the global debug state.

---
*PR created automatically by Jules for task [12304755487995988246](https://jules.google.com/task/12304755487995988246) started by @ljen*