### PR TITLE
Fix get_latest_folder_data_path nicer output on NotFound

### DIFF
--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -11,8 +11,17 @@ use arq::object_encryption;
 
 pub fn get_latest_folder_data_path(path: &Path) -> Result<PathBuf> {
     let mut newest = "0".to_string();
-    // TODO(nlopes): what if the path doesn't exist? Provide nicer output.
-    for entry in std::fs::read_dir(path)? {
+    let read_dir_result = match std::fs::read_dir(path) {
+        Ok(dir) => dir,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(crate::error::Error::NotFound(format!(
+                "Path not found: {}",
+                path.display()
+            )));
+        }
+        Err(e) => return Err(e.into()),
+    };
+    for entry in read_dir_result {
         let filename = entry?.file_name().to_str().unwrap().to_string();
         if filename > newest {
             newest = filename;


### PR DESCRIPTION
Addressed the TODO in get_latest_folder_data_path to return a nicer output error message containing the path when std::fs::read_dir returns a NotFound error.

---
*PR created automatically by Jules for task [14363310653995165841](https://jules.google.com/task/14363310653995165841) started by @ljen*