### PR TITLE
🧪 Add test for get_file_reader panic path

### DIFF
--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -88,3 +88,15 @@ macro_rules! debug_eprintln {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_get_file_reader_non_existent() {
+        let non_existent_path = PathBuf::from("non_existent_file.txt");
+        get_file_reader(non_existent_path);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a unit test for `get_file_reader` to verify that it correctly panics when given a path to a non-existent file.
📊 **Coverage:** The test covers the panic/error path of `get_file_reader`, asserting the panic with `#[should_panic]`.
✨ **Result:** Improved test coverage and reliability by explicitly testing the error-handling path.

---
*PR created automatically by Jules for task [1402541630039284443](https://jules.google.com/task/1402541630039284443) started by @ljen*