### PR TITLE
Refactor: change `glacier_archive_id` to `String` in `PackIndex`

### DIFF
--- a/arq/src/packset.rs
+++ b/arq/src/packset.rs
@@ -252,8 +252,7 @@ pub struct PackIndex {
     pub objects: Vec<PackIndexObject>,
 
     pub glacier_archive_id_present: bool,
-    // TODO(nlopes): maybe this should be String
-    pub glacier_archive_id: Vec<u8>,
+    pub glacier_archive_id: String,
     pub glacier_pack_size: usize,
 }
 
@@ -305,7 +304,7 @@ impl PackIndex {
         }
 
         let mut glacier_archive_id_present: bool = false;
-        let mut glacier_archive_id: Vec<u8> = Vec::new();
+        let mut glacier_archive_id: String = String::new();
         let mut glacier_pack_size = 0;
 
         // TODO(nlopes): This is ugly. I don't have a current position due to using a
@@ -323,9 +322,8 @@ impl PackIndex {
             if glacier_archive_id_flag[0] == 0x01 {
                 glacier_archive_id_present = true;
                 let glacier_archive_id_strlen = reader.read_u64::<NetworkEndian>()?;
-                glacier_archive_id = reader
-                    .read_bytes(glacier_archive_id_strlen as usize)?
-                    .to_vec();
+                let archive_id_bytes = reader.read_bytes(glacier_archive_id_strlen as usize)?;
+                glacier_archive_id = String::from_utf8(archive_id_bytes.to_vec())?;
                 glacier_pack_size = reader.read_u64::<NetworkEndian>()?;
             }
         }


### PR DESCRIPTION
Resolves a TODO in `arq/src/packset.rs` by changing the `glacier_archive_id` type in `PackIndex` from `Vec<u8>` to `String`. The parsing logic has been updated to decode the bytes into a UTF-8 string. Tested successfully.

---
*PR created automatically by Jules for task [14794960824648438985](https://jules.google.com/task/14794960824648438985) started by @ljen*