### PR TITLE
Remove global dead code allow and TODO

### DIFF
--- a/evu/src/lib.rs
+++ b/evu/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // TODO(nlopes): remove at the end
-
 extern crate arq;
 extern crate clap;
 extern crate rpassword;

--- a/evu/src/tree.rs
+++ b/evu/src/tree.rs
@@ -9,6 +9,7 @@ use arq::packset;
 use arq::tree;
 use arq::commit::{Commit};
 
+#[allow(dead_code)]
 fn show_commit(commit: &Commit) {
     println!(
         "   - author: {}, comment: {}, version: {}, location: {}",


### PR DESCRIPTION
Fixes the TODO at the top of `evu/src/lib.rs` by removing the global dead code allow directive. 
To prevent compiler warnings, it adds a localized `#[allow(dead_code)]` to the unused `show_commit` utility function in `tree.rs`.

---
*PR created automatically by Jules for task [2786616840346819860](https://jules.google.com/task/2786616840346819860) started by @ljen*