### PR TITLE
🔒 Prevent panic on non-UTF8 filename by using to_string_lossy()

### DIFF
--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -13,7 +13,7 @@ pub fn get_latest_folder_data_path(path: &Path) -> Result<PathBuf> {
     let mut newest = "0".to_string();
     // TODO(nlopes): what if the path doesn't exist? Provide nicer output.
     for entry in std::fs::read_dir(path)? {
-        let filename = entry?.file_name().to_str().unwrap().to_string();
+        let filename = entry?.file_name().to_string_lossy().to_string();
         if filename > newest {
             newest = filename;
         }
@@ -52,7 +52,7 @@ pub fn get_file_reader(filename: PathBuf) -> BufReader<File> {
         Ok(f) => f,
         Err(err) => panic!(
             "Could not open file {}: {}",
-            filename.as_path().to_str().unwrap(),
+            filename.as_path().to_string_lossy(),
             err
         ),
     };


### PR DESCRIPTION
🎯 **What:** Fixed a vulnerability in `evu/src/utils.rs` where the code explicitly called `.unwrap()` on `.to_str()` for filenames, causing panics on non-UTF8 paths.
⚠️ **Risk:** An attacker or misconfiguration could intentionally create a non-UTF8 filename, resulting in a denial-of-service (DoS) attack against the application due to runtime panic.
🛡️ **Solution:** Replaced `.to_str().unwrap()` with `.to_string_lossy()` to gracefully handle non-UTF8 characters, thereby avoiding the panic while preserving expected functionality. Addressed this in two places within `evu/src/utils.rs`.

---
*PR created automatically by Jules for task [1709727818081993699](https://jules.google.com/task/1709727818081993699) started by @ljen*