### PR TITLE
🧹 Remove outdated TODO and commented out code in backup_set.rs

### DIFF
--- a/arq/src/arq7/backup_set.rs
+++ b/arq/src/arq7/backup_set.rs
@@ -348,17 +348,7 @@ impl BackupSet {
         if !node.is_tree {
             return Ok(None);
         }
-        // TODO: This method needs to be implemented on crate::node::Node
-        // For now, assume it returns Ok(None) to allow compilation.
-        // This will affect functionality until `crate::node::Node::load_tree_with_encryption` is implemented.
-        // if let Some(tree) =
-        //     node.load_tree_with_encryption(backup_set_dir_ref, self.encryption_keyset.as_ref())?
-        // {
-        //     let target_name = path_parts[depth];
-        //     if let Some(child_node) = tree.child_nodes.get(target_name) {
-        //         return self.find_node_recursive(child_node, path_parts, depth + 1);
-        //     }
-        // }
+
         // Use the Node's own method now
         if let Some(tree) =
             node.load_tree_with_encryption(backup_set_dir_ref, self.encryption_keyset.as_ref())?


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code and an outdated TODO block in `arq/src/arq7/backup_set.rs`.
💡 **Why:** The commented-out code stated that `load_tree_with_encryption` was unimplemented. However, it was already implemented on the `Node` struct and being called correctly right below it. Removing the dead code cleans up the file and reduces confusion for developers reading the codebase.
✅ **Verification:** Verified that `load_tree_with_encryption` exists in `arq/src/node.rs`. Ran `cargo test` and `cargo check` in the `arq` directory to ensure the removal did not break functionality. All 75 unit/integration tests passed successfully.
✨ **Result:** A cleaner `backup_set.rs` file without confusing legacy comments, improving code readability.

---
*PR created automatically by Jules for task [6386989179688037539](https://jules.google.com/task/6386989179688037539) started by @ljen*