### PR TITLE
🧪 [Add tests for computers::show]

### DIFF
--- a/evu/src/computers.rs
+++ b/evu/src/computers.rs
@@ -29,10 +29,32 @@ pub fn show(path: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+    use std::io::Write;
 
     #[test]
     fn test_get_computers_invalid_path() {
         let result = get_computers("/nonexistent/path/that/should/fail");
         assert!(result.is_err(), "Expected an error for an invalid path");
+    }
+
+    #[test]
+    fn test_show_invalid_path() {
+        let result = show("/nonexistent/path/that/should/fail");
+        assert!(result.is_err(), "Expected an error for an invalid path in show");
+    }
+
+    #[test]
+    fn test_show_valid_path() {
+        let temp_dir = tempdir().unwrap();
+        let computer_dir = temp_dir.path().join("1234-5678");
+        std::fs::create_dir(&computer_dir).unwrap();
+
+        let mut file = std::fs::File::create(computer_dir.join("computerinfo")).unwrap();
+        let raw = "<plist><dict><key>userName</key><string>testuser</string><key>computerName</key><string>testcomputer</string></dict></plist>";
+        file.write_all(raw.as_bytes()).unwrap();
+
+        let result = show(temp_dir.path().to_str().unwrap());
+        assert!(result.is_ok(), "Expected Ok for a valid path");
     }
 }

--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -68,10 +68,17 @@ pub fn get_file_reader(filename: PathBuf) -> BufReader<File> {
     BufReader::new(file)
 }
 
+pub fn get_password() -> Result<String> {
+    if cfg!(test) {
+        return Ok("testpassword".to_string());
+    }
+    Ok(rpassword::prompt_password("Enter encryption password: ")?)
+}
+
 pub fn get_master_keys(path: &str, computer: &str) -> Result<Vec<Vec<u8>>> {
     let enc_path = Path::new(path).join(computer).join("encryptionv3.dat");
     let mut reader = get_file_reader(enc_path);
-    let password = rpassword::prompt_password("Enter encryption password: ")?;
+    let password = get_password()?;
     let enc_data = object_encryption::EncryptionDat::new(&mut reader, &password)?;
     Ok(enc_data.master_keys)
 }


### PR DESCRIPTION
🎯 **What:** The `show` method in `evu/src/computers.rs` was untested. I've added unit tests and test fixtures to test it successfully. Also extracted password logic to `get_password` in `utils.rs` so tests can mock it successfully and unblock the test suite.\n\n📊 **Coverage:** Added coverage for invalid path error condition and valid path success using `tempfile` fixtures to mimic ARQ computer plists.\n\n✨ **Result:** Test suite completes successfully without regressions and test coverage for the `show` method is significantly improved.

---
*PR created automatically by Jules for task [8334918921700394494](https://jules.google.com/task/8334918921700394494) started by @ljen*