### PR TITLE
🔒 Fix application panic on unreadable files in get_file_reader

### DIFF
--- a/evu/src/computers.rs
+++ b/evu/src/computers.rs
@@ -9,7 +9,7 @@ pub fn get_computers(path: &str) -> Result<Vec<ComputerInfo>> {
     let mut computers = Vec::new();
     for entry in fs::read_dir(path)? {
         let entry = entry.unwrap();
-        let reader = utils::get_file_reader(entry.path().join("computerinfo"));
+        let reader = utils::get_file_reader(entry.path().join("computerinfo"))?;
         computers.push(ComputerInfo::new(reader, entry.file_name().into_string()?)?);
     }
     Ok(computers)

--- a/evu/src/folders.rs
+++ b/evu/src/folders.rs
@@ -13,7 +13,7 @@ pub fn show(path: &str, computer: &str) -> Result<()> {
     println!("Folders\n-------");
     for entry in std::fs::read_dir(computers_path.join("buckets"))? {
         let filename = entry?.path();
-        let mut reader = utils::get_file_reader(filename);
+        let mut reader = utils::get_file_reader(filename)?;
         let folder = Folder::new(&mut reader, &master_keys)?;
         println!(
             "> [{}] ({}) Computer: {}",

--- a/evu/src/recovery.rs
+++ b/evu/src/recovery.rs
@@ -101,12 +101,12 @@ fn restore_object(
             let fname = entry?.file_name().to_str().unwrap().to_string();
             if fname.ends_with(".index") {
                 let index_path = path.join(&fname);
-                let mut reader = utils::get_file_reader(index_path);
+                let mut reader = utils::get_file_reader(index_path)?;
                 let index = packset::PackIndex::new(&mut reader)?;
                 for obj in index.objects {
                     if obj.sha1 == blob.blob_identifier { // Changed blob.sha1 to blob.blob_identifier
                         let pack_path = path.join(&fname.replace(".index", ".pack"));
-                        let mut reader = utils::get_file_reader(pack_path);
+                        let mut reader = utils::get_file_reader(pack_path)?;
                         reader.seek(SeekFrom::Start(obj.offset as u64))?;
                         let ob = packset::PackObject::new(&mut reader)?;
                         let mut f = File::create(filename)?;

--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -28,7 +28,7 @@ pub fn read_arq_folder(
     master_keys: Vec<Vec<u8>>,
 ) -> Result<Folder> {
     let path = Path::new(path).join(computer).join("buckets").join(folder);
-    let mut reader = get_file_reader(path);
+    let mut reader = get_file_reader(path)?;
     Ok(Folder::new(&mut reader, &master_keys)?)
 }
 
@@ -42,26 +42,31 @@ pub fn find_latest_folder_sha(path: &str, computer: &str, folder: &str) -> Resul
     let folder_data_path = get_latest_folder_data_path(&refs_path.join("logs").join("master"))?;
     let master_sha_path = refs_path.join("heads").join("master");
     let master_sha = std::fs::read(&master_sha_path)?;
-    let mut reader = get_file_reader(folder_data_path);
+    let mut reader = get_file_reader(folder_data_path)?;
     let fd = FolderData::new(&mut reader, &master_sha)?;
     Ok(fd.new_head_sha1)
 }
 
-pub fn get_file_reader(filename: PathBuf) -> BufReader<File> {
+pub fn get_file_reader(filename: PathBuf) -> Result<BufReader<File>> {
     let file = match File::open(&filename) {
         Ok(f) => f,
-        Err(err) => panic!(
-            "Could not open file {}: {}",
-            filename.as_path().to_str().unwrap(),
-            err
-        ),
+        Err(err) => {
+            return Err(crate::error::Error::IoError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Could not open file {}: {}",
+                    filename.as_path().to_str().unwrap(),
+                    err
+                ),
+            )))
+        }
     };
-    BufReader::new(file)
+    Ok(BufReader::new(file))
 }
 
 pub fn get_master_keys(path: &str, computer: &str) -> Result<Vec<Vec<u8>>> {
     let enc_path = Path::new(path).join(computer).join("encryptionv3.dat");
-    let mut reader = get_file_reader(enc_path);
+    let mut reader = get_file_reader(enc_path)?;
     let password = rpassword::prompt_password("Enter encryption password: ")?;
     let enc_data = object_encryption::EncryptionDat::new(&mut reader, &password)?;
     Ok(enc_data.master_keys)


### PR DESCRIPTION
🎯 What: Replaced a `panic!` call with a `Result::Err` return in the `get_file_reader` function in `evu/src/utils.rs` (around line 53). All callsites have been updated to propagate the error up instead of crashing the program. Note that the issue description originally mentioned `create_dir_all`, but the code at `evu/src/utils.rs:53` was using `File::open`.
⚠️ Risk: Denial of Service. The application would completely crash (panic) if it encountered a normal I/O error when trying to open a file (e.g., file not found, permission denied). This allows a trivial crash condition to be triggered.
🛡️ Solution: Updated the signature of `get_file_reader` from `BufReader<File>` to `Result<BufReader<File>>`. Changed the `match` block to return `Err(crate::error::Error::IoError(...))` instead of `panic!`. Added `?` operator to all callers of `get_file_reader` in `evu/src/utils.rs`, `evu/src/folders.rs`, `evu/src/computers.rs`, and `evu/src/recovery.rs` to propagate the error up the callstack safely.

---
*PR created automatically by Jules for task [18415287656624335921](https://jules.google.com/task/18415287656624335921) started by @ljen*