### PR TITLE
🧪 [testing improvement] Add tests for get_latest_folder_data_path

### DIFF
--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -109,7 +109,8 @@ macro_rules! debug_eprintln {
 mod tests {
     use super::*;
     use std::io::Read;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, tempdir};
+    use std::fs;
 
     #[test]
     fn test_get_file_reader_success() {
@@ -131,5 +132,41 @@ mod tests {
     fn test_get_file_reader_failure() {
         let non_existent_path = PathBuf::from("does_not_exist.txt");
         get_file_reader(non_existent_path);
+    }
+
+    #[test]
+    fn test_get_latest_folder_data_path_success() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let path = dir.path();
+
+        fs::File::create(path.join("001")).expect("Failed to create file");
+        fs::File::create(path.join("003")).expect("Failed to create file");
+        fs::File::create(path.join("002")).expect("Failed to create file");
+
+        let latest = get_latest_folder_data_path(path).expect("Failed to get latest path");
+        assert_eq!(latest, path.join("003"));
+    }
+
+    #[test]
+    fn test_get_latest_folder_data_path_empty_dir() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let path = dir.path();
+
+        let latest = get_latest_folder_data_path(path).expect("Failed to get latest path");
+        assert_eq!(latest, path.join("0"));
+    }
+
+    #[test]
+    fn test_get_latest_folder_data_path_missing_dir() {
+        let path = PathBuf::from("does_not_exist_dir");
+
+        let result = get_latest_folder_data_path(&path);
+        assert!(result.is_err());
+
+        if let Err(crate::error::Error::NotFound(msg)) = result {
+            assert_eq!(msg, format!("Path not found: {}", path.display()));
+        } else {
+            panic!("Expected NotFound error");
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for `get_latest_folder_data_path` in `evu/src/utils.rs` has been addressed.
📊 **Coverage:** The function is now tested for a populated directory (correctly selecting the newest file string-wise), an empty directory (falling back to "0"), and a missing directory (returning a NotFound error).
✨ **Result:** Test coverage and reliability of the `get_latest_folder_data_path` function have improved, preventing regressions in finding the latest folder data path.

---
*PR created automatically by Jules for task [1487747290122818544](https://jules.google.com/task/1487747290122818544) started by @ljen*