### PR TITLE
🧪 [testing improvement] Add unit tests for find_latest_folder_sha

### DIFF
--- a/evu/Cargo.toml
+++ b/evu/Cargo.toml
@@ -21,3 +21,4 @@ assert_cmd = "2.0"
 predicates = "3.0"
 tempfile = "3.3"
 serde_json = "1.0" # Added for temp test
+plist = "1.9.0"

--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -109,7 +109,67 @@ macro_rules! debug_eprintln {
 mod tests {
     use super::*;
     use std::io::Read;
-    use tempfile::NamedTempFile;
+    use std::fs;
+    use tempfile::{NamedTempFile, TempDir};
+    use plist;
+
+    #[test]
+    fn test_find_latest_folder_sha_not_found() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let base_path = temp_dir.path();
+
+        let result = find_latest_folder_sha(
+            base_path.to_str().unwrap(),
+            "test_computer",
+            "test_folder",
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_latest_folder_sha_success() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let base_path = temp_dir.path();
+        let computer = "test_computer";
+        let folder = "test_folder";
+
+        let refs_path = base_path
+            .join(computer)
+            .join("bucketdata")
+            .join(folder)
+            .join("refs");
+
+        let logs_master_path = refs_path.join("logs").join("master");
+        fs::create_dir_all(&logs_master_path).expect("Failed to create logs/master dir");
+
+        let heads_path = refs_path.join("heads");
+        fs::create_dir_all(&heads_path).expect("Failed to create heads dir");
+
+        let master_sha_path = heads_path.join("master");
+        fs::write(&master_sha_path, b"test_master_sha_short").expect("Failed to write master sha");
+
+        let folder_data_path = logs_master_path.join("1");
+        let mut file = File::create(&folder_data_path).expect("Failed to create folder data file");
+
+        let mut dict = plist::Dictionary::new();
+        dict.insert("newHeadSHA1".into(), plist::Value::String("test_new_head_sha".into()));
+        dict.insert("oldHeadSHA1".into(), plist::Value::String("test_old_head_sha".into()));
+        dict.insert("packSHA1".into(), plist::Value::String("test_pack_sha".into()));
+        dict.insert("old_head_stretch_key".into(), plist::Value::Boolean(false));
+        dict.insert("new_head_stretch_key".into(), plist::Value::Boolean(false));
+        dict.insert("is_rewrite".into(), plist::Value::Boolean(false));
+
+        plist::to_writer_xml(&mut file, &dict).expect("Failed to write plist");
+
+        let result = find_latest_folder_sha(
+            base_path.to_str().unwrap(),
+            computer,
+            folder,
+        ).expect("find_latest_folder_sha failed");
+
+        assert_eq!(result, "test_new_head_sha");
+    }
 
     #[test]
     fn test_get_file_reader_success() {


### PR DESCRIPTION
🎯 **What:** The `find_latest_folder_sha` function was untested. Added unit tests for this function.
📊 **Coverage:** Covered the happy path by simulating the filesystem operations by setting up a temp directory matching the expected `arq` repository layout (e.g., `refs/logs/master` and `refs/heads/master`) along with a valid plist object, ensuring the parsed result matches the expected SHA. Additionally covered the edge case when the `refs` directory is missing, ensuring an appropriate `Err` is returned.
✨ **Result:** Increased testing confidence in file-system operations retrieving folder configurations by bringing deterministic unit tests that execute locally and swiftly via `tempfile` instead of needing full integration setups.

---
*PR created automatically by Jules for task [10913488503573080379](https://jules.google.com/task/10913488503573080379) started by @ljen*