### PR TITLE
🧹 Fix: Clean up TODO comments for implemented method

### DIFF
--- a/arq/src/arq7/backup_set.rs
+++ b/arq/src/arq7/backup_set.rs
@@ -398,21 +398,6 @@ impl BackupSet {
             return Ok(());
         }
 
-        // TODO: This method needs to be implemented on crate::node::Node
-        // For now, assume it returns Ok(None) to allow compilation.
-        // This will affect functionality until `crate::node::Node::load_tree_with_encryption` is implemented.
-        // if let Some(tree) =
-        //     node.load_tree_with_encryption(backup_set_dir, self.encryption_keyset.as_ref())?
-        // {
-        //     for (name, child_node) in &tree.child_nodes {
-        //         let child_path = if current_path.is_empty() {
-        //             name.clone()
-        //         } else {
-        //             format!("{}/{}", current_path, name)
-        //         };
-        //         self.collect_files_recursive(child_node, child_path, files, backup_set_dir)?;
-        //     }
-        // }
         if let Some(tree) =
             node.load_tree_with_encryption(backup_set_dir, self.encryption_keyset.as_ref())?
         {
@@ -753,16 +738,6 @@ fn count_files_in_node(
     let mut file_count = 0u32;
     let mut total_size = 0u64;
 
-    // TODO: This method needs to be implemented on crate::node::Node
-    // For now, assume it returns Ok(None) to allow compilation.
-    // if let Some(tree) = node.load_tree_with_encryption(backup_set_dir, keyset)? {
-    //     for (_, child_node) in &tree.child_nodes {
-    //         let (child_files, child_size) =
-    //             count_files_in_node(child_node, backup_set_dir, keyset)?;
-    //         file_count += child_files;
-    //         total_size += child_size;
-    //     }
-    // }
     if let Some(tree) = node.load_tree_with_encryption(backup_set_dir, keyset)? {
         for (_, child_node_entry) in &tree.nodes {
             // Use tree.nodes


### PR DESCRIPTION
🎯 What
Removed old TODO comments and outdated commented-out code in `backup_set.rs` regarding the `load_tree_with_encryption` method.

💡 Why
The `load_tree_with_encryption` method is already implemented on `crate::node::Node`, and the code blocks beneath the comments are already actively calling this method and correctly iterating over `tree.nodes`. This cleans up dead/outdated comments.

✅ Verification
- Run `cd arq && cargo check` to ensure code compiles properly.
- Run `cd arq && cargo test --lib` to ensure all tests continue to pass.

✨ Result
Cleaner codebase without misleading TODOs for already implemented features.

---
*PR created automatically by Jules for task [7557314470281035464](https://jules.google.com/task/7557314470281035464) started by @ljen*