### PR TITLE
🧹 Remove commented-out NoneError implementation

### DIFF
--- a/evu/src/error.rs
+++ b/evu/src/error.rs
@@ -58,9 +58,3 @@ impl std::convert::From<arq::error::Error> for Error {
         Error::ArqError(error)
     }
 }
-
-// impl std::convert::From<std::option::NoneError> for Error {
-//     fn from(_error: std::option::NoneError) -> Error {
-//         Error::OptionError
-//     }
-// }


### PR DESCRIPTION
🎯 **What:** Removed commented-out implementation of `std::convert::From<std::option::NoneError>` for `Error` in `evu/src/error.rs`.
💡 **Why:** Cleans up unused dead code, improving codebase readability and maintainability.
✅ **Verification:** Verified that `cargo check` and `cargo test --lib` still pass inside the `evu` crate.
✨ **Result:** A cleaner `error.rs` file without unnecessary commented-out code.

---
*PR created automatically by Jules for task [265657336773290589](https://jules.google.com/task/265657336773290589) started by @ljen*