### PR TITLE
🧪 [testing improvement] Add test for LZ4 decompression error handling

### DIFF
--- a/arq/src/lz4.rs
+++ b/arq/src/lz4.rs
@@ -31,4 +31,13 @@ mod tests {
         // with zeros
         assert_eq!(test[..], decompressed[..test.len()]);
     }
+
+    #[test]
+    fn test_lz4_decompress_error() {
+        // First 4 bytes are original length (10 in big endian)
+        // Rest is invalid LZ4 data
+        let invalid_compressed = [0, 0, 0, 10, 255, 255, 255, 255];
+        let result = decompress(&invalid_compressed);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing error paths by passing invalid/corrupted LZ4 data to verify graceful failure instead of panics during decompression.

📊 **Coverage:** A new test scenario, `test_lz4_decompress_error` has been added, to simulate passing valid original length headers but invalid LZ4 payload bytes to the `decompress` function, verifying it correctly returns an `Err`.

✨ **Result:** The improvement in test coverage guarantees error safety in `arq/src/lz4.rs`, catching decompression bugs and potential panics, maintaining graceful failures when interacting with corrupted data payloads.

---
*PR created automatically by Jules for task [15828240901218462123](https://jules.google.com/task/15828240901218462123) started by @ljen*