### PR TITLE
🧪 Add tests for is_file_encrypted

### DIFF
--- a/arq/src/arq7/utils.rs
+++ b/arq/src/arq7/utils.rs
@@ -53,3 +53,70 @@ where
     let reader = BufReader::new(file);
     Ok(serde_json::from_reader(reader)?)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn get_temp_path(name: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        // Include thread ID to avoid conflicts when tests run concurrently
+        let thread_id = format!("{:?}", std::thread::current().id());
+        let thread_id = thread_id.replace("ThreadId(", "").replace(")", "");
+        std::env::temp_dir().join(format!("{}_{}_{}", name, thread_id, nanos))
+    }
+
+    #[test]
+    fn test_is_file_encrypted_true() {
+        let path = get_temp_path("encrypted");
+        {
+            let mut file = File::create(&path).unwrap();
+            file.write_all(b"ARQO_and_some_data").unwrap();
+        }
+
+        let result = is_file_encrypted(&path).unwrap();
+        assert!(result);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_is_file_encrypted_false_wrong_header() {
+        let path = get_temp_path("unencrypted");
+        {
+            let mut file = File::create(&path).unwrap();
+            file.write_all(b"NOT_ARQO_DATA").unwrap();
+        }
+
+        let result = is_file_encrypted(&path).unwrap();
+        assert!(!result);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_is_file_encrypted_false_too_small() {
+        let path = get_temp_path("small");
+        {
+            let mut file = File::create(&path).unwrap();
+            file.write_all(b"ARQ").unwrap(); // Only 3 bytes
+        }
+
+        let result = is_file_encrypted(&path).unwrap();
+        assert!(!result);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_is_file_encrypted_error_not_found() {
+        let path = get_temp_path("non_existent");
+        let result = is_file_encrypted(&path);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds missing unit tests for the `is_file_encrypted` helper function in `arq/src/arq7/utils.rs`. Previously, this function was not tested, making it a blind spot in the library test coverage.

📊 **Coverage:** What scenarios are now tested
The tests verify:
- Valid file with the "ARQO" header (returns `Ok(true)`).
- File with an invalid header (returns `Ok(false)`).
- File smaller than the required header length (returns `Ok(false)`).
- File missing or inaccessible (returns `Err`).

✨ **Result:** The improvement in test coverage
Increased the overall reliability and test coverage of `arq/src/arq7/utils.rs` by ensuring that standard and edge-case behaviors of `is_file_encrypted` are verified properly, without introducing dependencies.

---
*PR created automatically by Jules for task [16382186935665196460](https://jules.google.com/task/16382186935665196460) started by @ljen*