### PR TITLE
🧪 [add tests for decompress_data function]

### DIFF
--- a/arq/src/blob_location.rs
+++ b/arq/src/blob_location.rs
@@ -419,4 +419,81 @@ mod tests {
         assert_eq!(loc.blob_identifier, "abc123");
         assert_eq!(loc.relative_path, "/PLAN/blobpacks/AA/example.pack");
     }
+
+    fn create_test_blobloc(compression_type: u32) -> BlobLoc {
+        BlobLoc {
+            blob_identifier: "test".to_string(),
+            compression_type,
+            is_packed: false,
+            length: 0,
+            offset: 0,
+            relative_path: "".to_string(),
+            stretch_encryption_key: false,
+            is_large_pack: None,
+        }
+    }
+
+    #[test]
+    fn decompress_data_no_compression() {
+        let loc = create_test_blobloc(0);
+        let data = b"hello world".to_vec();
+        let result = loc.decompress_data(data.clone()).unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn decompress_data_gzip() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let loc = create_test_blobloc(1);
+        let original_data = b"hello world".to_vec();
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&original_data).unwrap();
+        let compressed_data = encoder.finish().unwrap();
+
+        let result = loc.decompress_data(compressed_data).unwrap();
+        assert_eq!(result, original_data);
+    }
+
+    #[test]
+    fn decompress_data_lz4() {
+        let loc = create_test_blobloc(2);
+        let original_data = b"hello world".to_vec();
+
+        let compressed_body = lz4_flex::block::compress(&original_data);
+        let mut compressed_data = Vec::new();
+        let uncompressed_len = original_data.len() as u32;
+        compressed_data.extend_from_slice(&uncompressed_len.to_be_bytes());
+        compressed_data.extend_from_slice(&compressed_body);
+
+        let result = loc.decompress_data(compressed_data).unwrap();
+        assert_eq!(result, original_data);
+    }
+
+    #[test]
+    fn decompress_data_lz4_empty() {
+        let loc = create_test_blobloc(2);
+        let empty_data = Vec::new();
+        let result = loc.decompress_data(empty_data.clone()).unwrap();
+        assert_eq!(result, empty_data);
+    }
+
+    #[test]
+    fn decompress_data_lz4_too_short() {
+        let loc = create_test_blobloc(2);
+        let short_data = b"123".to_vec();
+        let result = loc.decompress_data(short_data);
+        assert!(matches!(result, Err(Error::InvalidFormat(_))));
+    }
+
+    #[test]
+    fn decompress_data_unsupported_type() {
+        let loc = create_test_blobloc(3);
+        let data = b"hello world".to_vec();
+        let result = loc.decompress_data(data);
+        assert!(matches!(result, Err(Error::InvalidFormat(_))));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `decompress_data` function in `arq/src/blob_location.rs`. This function routes data through different decompression algorithms based on the `compression_type` of the blob, and tests were needed to ensure correct behavior across all supported types.

📊 **Coverage:** The following scenarios are now tested:
*   Compression type 0 (No compression): Verifies data is returned unaltered.
*   Compression type 1 (Gzip compression): Verifies correctly decompresses Gzip compressed data.
*   Compression type 2 (LZ4 compression): Verifies correctly decompresses LZ4 compressed data (including checking for the expected big-endian length prefix).
*   LZ4 Edge Case: Verifies empty data is handled gracefully.
*   LZ4 Edge Case: Verifies an error is returned if data is shorter than the length prefix but non-empty.
*   Unsupported compression types: Verifies an error is returned for unknown types.

✨ **Result:** Test coverage for `BlobLoc::decompress_data` is now robust, verifying both happy paths and edge cases for the main compression strategies, ensuring safer refactoring in the future.

---
*PR created automatically by Jules for task [2349171924270062806](https://jules.google.com/task/2349171924270062806) started by @ljen*