### PR TITLE
🧪 Add tests for `is_valid_path` edge cases

### DIFF
--- a/arq/src/blob_location.rs
+++ b/arq/src/blob_location.rs
@@ -401,6 +401,38 @@ mod tests {
     }
 
     #[test]
+    fn test_is_valid_path() {
+        // Valid paths
+        assert!(BlobLoc::is_valid_path("/path/to/backup"));
+        assert!(BlobLoc::is_valid_path("/path/to/backup.pack"));
+        assert!(BlobLoc::is_valid_path("/backup-123_456.pack"));
+        assert!(BlobLoc::is_valid_path("/a:b(c) d")); // valid chars: ':', '(', ')', ' '
+        assert!(BlobLoc::is_valid_path("treepacks/something"));
+        assert!(BlobLoc::is_valid_path("blobpacks/something"));
+        assert!(BlobLoc::is_valid_path("largeblobpacks/something"));
+        assert!(BlobLoc::is_valid_path("standardobjects/something"));
+        assert!(BlobLoc::is_valid_path("blob/something"));
+        assert!(BlobLoc::is_valid_path("something.pack"));
+
+        // Invalid paths
+        assert!(!BlobLoc::is_valid_path(""));
+
+        let long_path = "a".repeat(4097);
+        assert!(!BlobLoc::is_valid_path(&long_path));
+
+        // Missing leading slash and no backup pattern
+        assert!(!BlobLoc::is_valid_path("just/a/normal/path"));
+
+        // Invalid characters
+        assert!(!BlobLoc::is_valid_path("/invalid/path\n")); // control char
+        assert!(!BlobLoc::is_valid_path("/invalid/path*")); // forbidden char '*'
+        assert!(!BlobLoc::is_valid_path("/invalid/path?")); // forbidden char '?'
+        assert!(!BlobLoc::is_valid_path("/invalid/path<")); // forbidden char '<'
+        assert!(!BlobLoc::is_valid_path("/invalid/path>")); // forbidden char '>'
+        assert!(!BlobLoc::is_valid_path("/invalid/path|")); // forbidden char '|'
+    }
+
+    #[test]
     fn parses_official_arq7_binary_blobloc_from_non_seek_reader() {
         let mut data = Vec::new();
         data.extend(arq_string("abc123"));


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `is_valid_path` function in `arq/src/blob_location.rs` lacked unit tests. It is a pure string validation function whose correctness is crucial for processing blob locations correctly, and edge cases should be tested thoroughly.

📊 **Coverage:** What scenarios are now tested
Tests cover:
- Empty paths
- Paths exceeding the 4096 character length limit
- Valid paths with proper absolute prefixes and valid characters
- Valid relative paths containing backup-related patterns
- Invalid absolute paths with invalid characters (e.g. control characters, `*`, `?`, etc.)
- Invalid relative paths missing backup patterns

✨ **Result:** The improvement in test coverage
The `test_is_valid_path` unit test function now thoroughly verifies the string validation rules enforced by the `is_valid_path` function, capturing both happy paths and edge cases to prevent future regressions.

---
*PR created automatically by Jules for task [12417081893037539131](https://jules.google.com/task/12417081893037539131) started by @ljen*