### PR TITLE
🧪 Add test for invalid read_arq_string

### DIFF
--- a/arq/src/type_utils.rs
+++ b/arq/src/type_utils.rs
@@ -175,6 +175,13 @@ mod tests {
     }
 
     #[test]
+    fn test_read_arq_string_invalid_utf8() {
+        let mut reader_invalid = Cursor::new(vec![1, 0, 0, 0, 0, 0, 0, 0, 2, 255, 255]);
+        let result = reader_invalid.read_arq_string();
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_read_arq_data() {
         let empty: Vec<u8> = vec![];
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing test coverage for `read_arq_string` encountering invalid UTF-8 bytes when reading the string data payload from a `Cursor`.
📊 **Coverage:** The new test, `test_read_arq_string_invalid_utf8`, ensures that if a cursor provides a string presence flag (`0x01`), a valid length, but invalid UTF-8 bytes, `read_arq_string` gracefully returns an error rather than panicking or misbehaving.
✨ **Result:** Increased code reliability and test coverage by validating the error path of UTF-8 decoding during Arq7 string deserialization.

---
*PR created automatically by Jules for task [13226196708182585016](https://jules.google.com/task/13226196708182585016) started by @ljen*