### PR TITLE
🧪 [Testing Improvement] Add test for get_password using environment variable

### DIFF
--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -191,6 +191,22 @@ mod tests {
     }
 
     #[test]
+    fn test_get_password_env_var() {
+        let test_pass = "my_super_secret_password_123";
+        unsafe {
+            std::env::set_var("ARQ_PASSWORD", test_pass);
+        }
+
+        let result = get_password();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), test_pass);
+
+        unsafe {
+            std::env::remove_var("ARQ_PASSWORD");
+        }
+    }
+
+    #[test]
     fn test_is_debug_enabled_default() {
         // By default, the IS_DEBUG atomic bool should be initialized to false.
         assert_eq!(is_debug_enabled(), false);


### PR DESCRIPTION
🎯 **What:** Added missing test for `get_password` function in `evu/src/utils.rs` to ensure it properly falls back to `ARQ_PASSWORD` environment variable.
📊 **Coverage:** Covered the scenario where `ARQ_PASSWORD` is set, testing the correct reading and returning of the value.
✨ **Result:** Improved test coverage and reliability for password retrieval utility function.

---
*PR created automatically by Jules for task [1661763660471569845](https://jules.google.com/task/1661763660471569845) started by @ljen*