### PR TITLE
🔒 Fix path traversal during node extraction

### DIFF
--- a/evu/src/arq7_handler.rs
+++ b/evu/src/arq7_handler.rs
@@ -1119,7 +1119,10 @@ fn extract_node_to_destination_recursive(
     let node_output_path = if relative_path_for_node.is_empty() {
         current_materialized_path.to_path_buf()
     } else {
-        current_materialized_path.join(relative_path_for_node)
+        let safe_name = std::path::Path::new(relative_path_for_node)
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("invalid_node_name"));
+        current_materialized_path.join(safe_name)
     };
 
     if node.is_tree {


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `extract_node_to_destination_recursive` within `evu/src/arq7_handler.rs`.

⚠️ **Risk:** The previous implementation blindly joined the `relative_path_for_node` extracted from backup files onto the materialized destination directory. This could have permitted a maliciously constructed ARQ7 backup containing path structures like `../../` or absolute path anchors to write arbitrarily outside the extraction target, potentially overwriting sensitive system or application files.

🛡️ **Solution:** The resolution introduces safety by extracting solely the `file_name()` component of `relative_path_for_node`. If this operation fails (such as in instances of raw `..` or `.`), a default fallback of `"invalid_node_name"` is securely substituted. This restricts all file restoration activities strictly inside the expected target destination.

---
*PR created automatically by Jules for task [3615881659883087641](https://jules.google.com/task/3615881659883087641) started by @ljen*