### PR TITLE
🧹 [code health improvement] Refactor restore_file_in_tree to use options struct

### DIFF
--- a/evu/src/recovery.rs
+++ b/evu/src/recovery.rs
@@ -10,6 +10,13 @@ use arq::commit::Commit;
 use arq::packset;
 use arq::tree;
 
+pub struct RestoreOptions<'a> {
+    pub path: &'a PathBuf,
+    pub absolute_filepath: &'a str,
+    pub folder: &'a str,
+    pub keyset: &'a EncryptedKeySet,
+}
+
 pub fn restore_file(
     path: &str,
     computer: &str,
@@ -33,42 +40,44 @@ pub fn restore_file(
     let arq_folder = utils::read_arq_folder(path, computer, folder, master_keys.clone())?;
     let tree_blob = packset::restore_blob_with_sha(&trees_path, &commit.tree_sha1, &keyset)?;
     let tree = tree::Tree::new_arq5(&tree_blob, commit.tree_compression_type)?;
-    restore_file_in_tree(
-        Path::new(&arq_folder.local_path),
-        &trees_path,
+
+    let options = RestoreOptions {
+        path: &trees_path,
         absolute_filepath,
         folder,
+        keyset: &keyset,
+    };
+
+    restore_file_in_tree(
+        Path::new(&arq_folder.local_path),
         tree,
-        &keyset,
+        &options,
     )
 }
 
 fn restore_file_in_tree(
     prefix: &Path,
-    path: &PathBuf,
-    absolute_filepath: &str,
-    folder: &str,
     tree: tree::Tree,
-    keyset: &EncryptedKeySet,
+    options: &RestoreOptions,
 ) -> Result<()> {
     for (name, node) in tree.nodes {
         if !node.is_tree {
             let inner = prefix.join(name);
-            if inner.as_os_str().to_string_lossy() == absolute_filepath {
+            if inner.as_os_str().to_string_lossy() == options.absolute_filepath {
                 restore_object(
-                    path,
-                    folder,
+                    options.path,
+                    options.folder,
                     &node,
-                    absolute_filepath,
-                    &keyset.encryption_key,
+                    options.absolute_filepath,
+                    &options.keyset.encryption_key,
                 )?;
                 // Passed node as reference
             }
         } else {
             let data = packset::restore_blob_with_sha(
-                path,
+                options.path,
                 &node.data_blob_locs[0].blob_identifier,
-                keyset,
+                options.keyset,
             )?; // Changed to data_blob_locs and blob_identifier
             let inner_tree = tree::Tree::new_arq5(
                 &data,
@@ -77,11 +86,8 @@ fn restore_file_in_tree(
             )?; // Changed to arq5_data_compression_type
             restore_file_in_tree(
                 prefix.join(name).as_path(),
-                path,
-                absolute_filepath,
-                folder,
                 inner_tree,
-                keyset,
+                options,
             )?;
         }
     }


### PR DESCRIPTION
🎯 **What:** 
Refactored the `restore_file_in_tree` function in `evu/src/recovery.rs` to group static parameters (`path`, `absolute_filepath`, `folder`, and `keyset`) into a single `RestoreOptions` struct.

💡 **Why:**
The function previously took 6 arguments, which makes the signature cumbersome and violates clean code principles ("too many arguments"). By extracting the parameters that do not change during recursion into an options struct, the code becomes cleaner, more maintainable, and easier to read.

✅ **Verification:**
- Verified the code compiles successfully (`cargo check --lib` in `evu`).
- Executed the full unit test suite for both `evu` and `arq` crates (`cargo test --lib`), confirming no regressions were introduced.
- Received a `#Correct#` rating from the code review tool.

✨ **Result:**
The `restore_file_in_tree` function signature is now simplified to 3 arguments, improving the overall readability and health of the codebase while preserving all existing functionality.

---
*PR created automatically by Jules for task [408640364327767613](https://jules.google.com/task/408640364327767613) started by @ljen*