### PR TITLE
🧹 [Code Health] Refactor `main` subcommands into dedicated handler functions

### DIFF
--- a/evu/benches/recovery_benchmark.rs
+++ b/evu/benches/recovery_benchmark.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::PathBuf;
@@ -22,7 +22,8 @@ fn benchmark_read_dir_uncached(c: &mut Criterion) {
     c.bench_function("read_dir_uncached", |b| {
         b.iter(|| {
             let mut matches = 0;
-            for _blob in 0..10 { // Simulate 10 data_blob_locs
+            for _blob in 0..10 {
+                // Simulate 10 data_blob_locs
                 for entry in fs::read_dir(&path).unwrap() {
                     let entry = entry.unwrap();
                     let fname = entry.file_name().to_string_lossy().to_string();
@@ -52,7 +53,8 @@ fn benchmark_read_dir_cached(c: &mut Criterion) {
                 }
             }
 
-            for _blob in 0..10 { // Simulate 10 data_blob_locs
+            for _blob in 0..10 {
+                // Simulate 10 data_blob_locs
                 for fname in &cached_entries {
                     matches += 1;
                 }
@@ -62,5 +64,9 @@ fn benchmark_read_dir_cached(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, benchmark_read_dir_uncached, benchmark_read_dir_cached);
+criterion_group!(
+    benches,
+    benchmark_read_dir_uncached,
+    benchmark_read_dir_cached
+);
 criterion_main!(benches);

--- a/evu/src/main.rs
+++ b/evu/src/main.rs
@@ -3,6 +3,127 @@ extern crate evu;
 use evu::autodetect::{ArqVersion, detect_version};
 use std::path::Path;
 
+fn handle_show(
+    version: ArqVersion,
+    cmd: &clap::ArgMatches,
+    global_path: &Path,
+    global_path_str: &str,
+) -> Result<(), evu::error::Error> {
+    match version {
+        ArqVersion::Arq5 => {
+            let computer_uuid = global_path.file_name().unwrap().to_str().unwrap();
+            match cmd.subcommand() {
+                ("folders", Some(_)) => evu::folders::show(global_path_str, computer_uuid)?,
+                ("tree", Some(c)) => evu::tree::show(
+                    global_path_str,
+                    computer_uuid,
+                    c.value_of("folder").unwrap(),
+                )?,
+                _ => println!("Invalid 'show' subcommand for Arq 5. Use --help for details."),
+            }
+        }
+        ArqVersion::Arq7 => match cmd.subcommand() {
+            ("records", Some(_)) => {
+                evu::arq7_handler::list_backup_records(global_path)?;
+            }
+            ("file-versions", Some(sub_matches)) => {
+                let file_path = sub_matches.value_of("file").unwrap();
+                evu::arq7_handler::list_file_versions(global_path, file_path)?;
+            }
+            ("folder-versions", Some(sub_matches)) => {
+                let folder_path = sub_matches.value_of("folder").unwrap();
+                evu::arq7_handler::list_folder_versions(global_path, folder_path)?;
+            }
+            _ => println!("Invalid 'show' subcommand for Arq 7. Use --help for details."),
+        },
+    }
+    Ok(())
+}
+
+fn handle_restore(
+    version: ArqVersion,
+    cmd: &clap::ArgMatches,
+    global_path: &Path,
+    global_path_str: &str,
+) -> Result<(), evu::error::Error> {
+    match version {
+        ArqVersion::Arq5 => {
+            let computer_uuid = global_path.file_name().unwrap().to_str().unwrap();
+            let folder = cmd.value_of("folder").ok_or_else(|| {
+                evu::error::Error::CliInputError(
+                    "Arq 5 restore requires --folder <folder>".to_string(),
+                )
+            })?;
+            let filepath = cmd.value_of("FILEPATH").ok_or_else(|| {
+                evu::error::Error::CliInputError("Arq 5 restore requires <FILEPATH>".to_string())
+            })?;
+            evu::recovery::restore_file(global_path_str, computer_uuid, folder, filepath)?
+        }
+        ArqVersion::Arq7 => match cmd.subcommand() {
+            ("record", Some(sub_matches)) => {
+                let record_id = sub_matches.value_of("record").unwrap();
+                let dest_str = sub_matches.value_of("destination").unwrap();
+                evu::arq7_handler::restore_full_record(
+                    global_path,
+                    record_id,
+                    Path::new(dest_str),
+                )?;
+            }
+            ("file", Some(sub_matches)) => {
+                let record_id = sub_matches.value_of("record").unwrap();
+                let file_path = sub_matches.value_of("file").unwrap();
+                let dest_str = sub_matches.value_of("destination").unwrap();
+                evu::arq7_handler::restore_specific_file_from_record(
+                    global_path,
+                    record_id,
+                    file_path,
+                    Path::new(dest_str),
+                )?;
+            }
+            ("folder", Some(sub_matches)) => {
+                let record_id = sub_matches.value_of("record").unwrap();
+                let folder_path = sub_matches.value_of("folder").unwrap();
+                let dest_str = sub_matches.value_of("destination").unwrap();
+                evu::arq7_handler::restore_specific_folder_from_record(
+                    global_path,
+                    record_id,
+                    folder_path,
+                    Path::new(dest_str),
+                )?;
+            }
+            ("all-folder-versions", Some(sub_matches)) => {
+                let folder_path = sub_matches.value_of("folder").unwrap();
+                let dest_root_str = sub_matches.value_of("destination-root").unwrap();
+                evu::arq7_handler::restore_all_folder_versions(
+                    global_path,
+                    folder_path,
+                    Path::new(dest_root_str),
+                )?;
+            }
+            _ => println!("Invalid 'restore' subcommand for Arq 7. Use --help for details."),
+        },
+    }
+    Ok(())
+}
+
+fn handle_list_files(
+    version: ArqVersion,
+    cmd: &clap::ArgMatches,
+    global_path: &Path,
+) -> Result<(), evu::error::Error> {
+    match version {
+        ArqVersion::Arq7 => {
+            let record_id = cmd.value_of("record");
+            let folder_path = cmd.value_of("folder");
+            evu::arq7_handler::list_files(global_path, record_id, folder_path)?;
+        }
+        ArqVersion::Arq5 => {
+            println!("'list-files' is not supported for Arq 5 backups.");
+        }
+    }
+    Ok(())
+}
+
 fn main() -> Result<(), evu::error::Error> {
     let matches = evu::cli::parse_flags();
 
@@ -16,103 +137,9 @@ fn main() -> Result<(), evu::error::Error> {
     let version = detect_version(global_path)?;
 
     match matches.subcommand() {
-        ("show", Some(cmd)) => match version {
-            ArqVersion::Arq5 => {
-                let computer_uuid = global_path.file_name().unwrap().to_str().unwrap();
-                match cmd.subcommand() {
-                    ("folders", Some(_)) => evu::folders::show(global_path_str, computer_uuid)?,
-                    ("tree", Some(c)) => evu::tree::show(
-                        global_path_str,
-                        computer_uuid,
-                        c.value_of("folder").unwrap(),
-                    )?,
-                    _ => println!("Invalid 'show' subcommand for Arq 5. Use --help for details."),
-                }
-            }
-            ArqVersion::Arq7 => match cmd.subcommand() {
-                ("records", Some(_)) => {
-                    evu::arq7_handler::list_backup_records(global_path)?;
-                }
-                ("file-versions", Some(sub_matches)) => {
-                    let file_path = sub_matches.value_of("file").unwrap();
-                    evu::arq7_handler::list_file_versions(global_path, file_path)?;
-                }
-                ("folder-versions", Some(sub_matches)) => {
-                    let folder_path = sub_matches.value_of("folder").unwrap();
-                    evu::arq7_handler::list_folder_versions(global_path, folder_path)?;
-                }
-                _ => println!("Invalid 'show' subcommand for Arq 7. Use --help for details."),
-            },
-        },
-        ("restore", Some(cmd)) => match version {
-            ArqVersion::Arq5 => {
-                let computer_uuid = global_path.file_name().unwrap().to_str().unwrap();
-                let folder = cmd.value_of("folder").ok_or_else(|| {
-                    evu::error::Error::CliInputError(
-                        "Arq 5 restore requires --folder <folder>".to_string(),
-                    )
-                })?;
-                let filepath = cmd.value_of("FILEPATH").ok_or_else(|| {
-                    evu::error::Error::CliInputError(
-                        "Arq 5 restore requires <FILEPATH>".to_string(),
-                    )
-                })?;
-                evu::recovery::restore_file(global_path_str, computer_uuid, folder, filepath)?
-            }
-            ArqVersion::Arq7 => match cmd.subcommand() {
-                ("record", Some(sub_matches)) => {
-                    let record_id = sub_matches.value_of("record").unwrap();
-                    let dest_str = sub_matches.value_of("destination").unwrap();
-                    evu::arq7_handler::restore_full_record(
-                        global_path,
-                        record_id,
-                        Path::new(dest_str),
-                    )?;
-                }
-                ("file", Some(sub_matches)) => {
-                    let record_id = sub_matches.value_of("record").unwrap();
-                    let file_path = sub_matches.value_of("file").unwrap();
-                    let dest_str = sub_matches.value_of("destination").unwrap();
-                    evu::arq7_handler::restore_specific_file_from_record(
-                        global_path,
-                        record_id,
-                        file_path,
-                        Path::new(dest_str),
-                    )?;
-                }
-                ("folder", Some(sub_matches)) => {
-                    let record_id = sub_matches.value_of("record").unwrap();
-                    let folder_path = sub_matches.value_of("folder").unwrap();
-                    let dest_str = sub_matches.value_of("destination").unwrap();
-                    evu::arq7_handler::restore_specific_folder_from_record(
-                        global_path,
-                        record_id,
-                        folder_path,
-                        Path::new(dest_str),
-                    )?;
-                }
-                ("all-folder-versions", Some(sub_matches)) => {
-                    let folder_path = sub_matches.value_of("folder").unwrap();
-                    let dest_root_str = sub_matches.value_of("destination-root").unwrap();
-                    evu::arq7_handler::restore_all_folder_versions(
-                        global_path,
-                        folder_path,
-                        Path::new(dest_root_str),
-                    )?;
-                }
-                _ => println!("Invalid 'restore' subcommand for Arq 7. Use --help for details."),
-            },
-        },
-        ("list-files", Some(cmd)) => match version {
-            ArqVersion::Arq7 => {
-                let record_id = cmd.value_of("record");
-                let folder_path = cmd.value_of("folder");
-                evu::arq7_handler::list_files(global_path, record_id, folder_path)?;
-            }
-            ArqVersion::Arq5 => {
-                println!("'list-files' is not supported for Arq 5 backups.");
-            }
-        },
+        ("show", Some(cmd)) => handle_show(version, cmd, global_path, global_path_str)?,
+        ("restore", Some(cmd)) => handle_restore(version, cmd, global_path, global_path_str)?,
+        ("list-files", Some(cmd)) => handle_list_files(version, cmd, global_path)?,
         _ => {
             println!("No command specified or unknown command. Use --help for available commands.");
         }

--- a/evu/src/recovery.rs
+++ b/evu/src/recovery.rs
@@ -127,8 +127,7 @@ fn restore_object(
                 if obj.sha1 == blob.blob_identifier {
                     // Changed blob.sha1 to blob.blob_identifier
                     let pack_path = path.join(&fname.replace(".index", ".pack"));
-                    let mut reader =
-                        std::io::BufReader::new(utils::get_file_reader(&pack_path)?);
+                    let mut reader = std::io::BufReader::new(utils::get_file_reader(&pack_path)?);
                     reader.seek(SeekFrom::Start(obj.offset as u64))?;
                     let mut reader = std::io::BufReader::new(reader);
                     let ob = packset::PackObject::new(&mut reader)?;


### PR DESCRIPTION
🎯 **What:** The `main` function in `evu/src/main.rs` was overly long due to inline handling of various CLI subcommands (`show`, `restore`, `list-files`). These have been extracted into dedicated handler functions (`handle_show`, `handle_restore`, `handle_list_files`).
💡 **Why:** Breaking down the monolithic `main` function improves readability and maintainability. It simplifies testing, makes the codebase easier to navigate, and logically groups the respective command-line actions into manageable units.
✅ **Verification:** Verified by compiling the code (`cargo check`) and running all library tests (`cargo test --lib`) successfully. The application behavior remains completely unchanged.
✨ **Result:** The `main` function is now concise and primarily serves as a router to the respective subcommand handlers, enhancing code organization without altering runtime functionality.

---
*PR created automatically by Jules for task [1971562751607695397](https://jules.google.com/task/1971562751607695397) started by @ljen*