### PR TITLE
🧹 [Code Health] Refactor `extract_node_to_destination_recursive` for better readability

### DIFF
--- a/evu/benches/recovery_benchmark.rs
+++ b/evu/benches/recovery_benchmark.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::PathBuf;
@@ -22,7 +22,8 @@ fn benchmark_read_dir_uncached(c: &mut Criterion) {
     c.bench_function("read_dir_uncached", |b| {
         b.iter(|| {
             let mut matches = 0;
-            for _blob in 0..10 { // Simulate 10 data_blob_locs
+            for _blob in 0..10 {
+                // Simulate 10 data_blob_locs
                 for entry in fs::read_dir(&path).unwrap() {
                     let entry = entry.unwrap();
                     let fname = entry.file_name().to_string_lossy().to_string();
@@ -52,7 +53,8 @@ fn benchmark_read_dir_cached(c: &mut Criterion) {
                 }
             }
 
-            for _blob in 0..10 { // Simulate 10 data_blob_locs
+            for _blob in 0..10 {
+                // Simulate 10 data_blob_locs
                 for fname in &cached_entries {
                     matches += 1;
                 }
@@ -62,5 +64,9 @@ fn benchmark_read_dir_cached(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, benchmark_read_dir_uncached, benchmark_read_dir_cached);
+criterion_group!(
+    benches,
+    benchmark_read_dir_uncached,
+    benchmark_read_dir_cached
+);
 criterion_main!(benches);

--- a/evu/src/arq7_handler.rs
+++ b/evu/src/arq7_handler.rs
@@ -638,13 +638,16 @@ pub fn restore_full_record(
             );
 
             let mut stats = ExtractionStats::default();
-            extract_node_to_destination_recursive(
-                &arq7_record.node, // Access node from arq7_record
+            let mut ctx = ExtractionContext {
                 backup_set_path,
                 keyset,
+                stats: &mut stats,
+            };
+            extract_node_to_destination_recursive(
+                &arq7_record.node, // Access node from arq7_record
                 &final_destination,
                 "",
-                &mut stats,
+                &mut ctx,
             )?;
             println!(
                 "Successfully restored record. Files: {}, Dirs: {}, Total Size: {} bytes. Errors: {}",
@@ -895,13 +898,16 @@ pub fn restore_specific_folder_from_record(
     );
 
     let mut stats = ExtractionStats::default();
-    extract_node_to_destination_recursive(
-        &target_node,
+    let mut ctx = ExtractionContext {
         backup_set_path,
         keyset,
+        stats: &mut stats,
+    };
+    extract_node_to_destination_recursive(
+        &target_node,
         &final_destination_for_folder_content,
         "",
-        &mut stats,
+        &mut ctx,
     )?;
 
     println!(
@@ -1039,13 +1045,16 @@ pub fn restore_all_folder_versions(
                                 final_content_destination.display()
                             );
                             let mut stats = ExtractionStats::default();
-                            match extract_node_to_destination_recursive(
-                                &target_node,
+                            let mut ctx = ExtractionContext {
                                 backup_set_path,
                                 keyset,
+                                stats: &mut stats,
+                            };
+                            match extract_node_to_destination_recursive(
+                                &target_node,
                                 &final_content_destination,
                                 "",
-                                &mut stats,
+                                &mut ctx,
                             ) {
                                 Ok(_) => {
                                     println!(
@@ -1108,13 +1117,17 @@ struct ExtractionStats {
     errors: usize,
 }
 
+struct ExtractionContext<'a> {
+    backup_set_path: &'a Path,
+    keyset: Option<&'a EncryptedKeySet>,
+    stats: &'a mut ExtractionStats,
+}
+
 fn extract_node_to_destination_recursive(
     node: &Node,
-    backup_set_path: &Path,
-    keyset: Option<&EncryptedKeySet>,
     current_materialized_path: &Path,
     relative_path_for_node: &str,
-    stats: &mut ExtractionStats,
+    ctx: &mut ExtractionContext<'_>,
 ) -> Result<()> {
     let node_output_path = if relative_path_for_node.is_empty() {
         current_materialized_path.to_path_buf()
@@ -1125,22 +1138,20 @@ fn extract_node_to_destination_recursive(
     if node.is_tree {
         if !node_output_path.exists() {
             std::fs::create_dir_all(&node_output_path).map_err(Error::IoError)?;
-            stats.dirs_created += 1;
+            ctx.stats.dirs_created += 1;
         }
 
-        match node.load_tree_with_encryption(backup_set_path, keyset) {
+        match node.load_tree_with_encryption(ctx.backup_set_path, ctx.keyset) {
             Ok(Some(tree)) => {
                 for (child_name, child_node) in &tree.nodes {
                     if let Err(e) = extract_node_to_destination_recursive(
                         child_node,
-                        backup_set_path,
-                        keyset,
                         &node_output_path,
                         child_name,
-                        stats,
+                        ctx,
                     ) {
                         debug_eprintln!("Error processing child '{}': {}", child_name, e);
-                        stats.errors += 1;
+                        ctx.stats.errors += 1;
                     }
                 }
             }
@@ -1156,7 +1167,7 @@ fn extract_node_to_destination_recursive(
                     node_output_path.display(),
                     e
                 );
-                stats.errors += 1;
+                ctx.stats.errors += 1;
             }
         }
     } else {
@@ -1166,11 +1177,11 @@ fn extract_node_to_destination_recursive(
             }
         }
 
-        match node.reconstruct_file_data_with_encryption(backup_set_path, keyset) {
+        match node.reconstruct_file_data_with_encryption(ctx.backup_set_path, ctx.keyset) {
             Ok(file_data) => {
                 std::fs::write(&node_output_path, &file_data).map_err(Error::IoError)?;
-                stats.files_restored += 1;
-                stats.bytes_restored += file_data.len() as u64;
+                ctx.stats.files_restored += 1;
+                ctx.stats.bytes_restored += file_data.len() as u64;
 
                 if node.modification_time_sec > 0 {
                     use std::time::UNIX_EPOCH;
@@ -1190,7 +1201,7 @@ fn extract_node_to_destination_recursive(
                     node_output_path.display(),
                     e
                 );
-                stats.errors += 1;
+                ctx.stats.errors += 1;
             }
         }
     }

--- a/evu/src/recovery.rs
+++ b/evu/src/recovery.rs
@@ -127,8 +127,7 @@ fn restore_object(
                 if obj.sha1 == blob.blob_identifier {
                     // Changed blob.sha1 to blob.blob_identifier
                     let pack_path = path.join(&fname.replace(".index", ".pack"));
-                    let mut reader =
-                        std::io::BufReader::new(utils::get_file_reader(&pack_path)?);
+                    let mut reader = std::io::BufReader::new(utils::get_file_reader(&pack_path)?);
                     reader.seek(SeekFrom::Start(obj.offset as u64))?;
                     let mut reader = std::io::BufReader::new(reader);
                     let ob = packset::PackObject::new(&mut reader)?;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the excessive number of arguments in `extract_node_to_destination_recursive`. We addressed this by combining `backup_set_path`, `keyset`, and `stats` into a single `ExtractionContext` struct.
💡 **Why:** This improves maintainability and readability by logically grouping related, context-level arguments, which makes the function signature cleaner and reduces the cognitive load required to understand and call the function.
✅ **Verification:** Verified by compiling the code, successfully running `cargo check`, formatting the code using `cargo fmt`, and successfully running all unit tests with `cargo test --lib` within the `evu` crate directory. A full code review was requested and passed correctly, indicating no regressions and ensuring correct usage of mutable references in Rust.
✨ **Result:** The `extract_node_to_destination_recursive` function now takes 4 parameters instead of 6, improving code maintainability.

---
*PR created automatically by Jules for task [8990971299809859792](https://jules.google.com/task/8990971299809859792) started by @ljen*