### PR TITLE
🧪 [Testing improvement: Add test for to_master_keys in encrypted_keyset]

### DIFF
--- a/arq/src/arq7/encrypted_keyset.rs
+++ b/arq/src/arq7/encrypted_keyset.rs
@@ -170,3 +170,24 @@ impl EncryptedKeySet {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_master_keys() {
+        let keyset = EncryptedKeySet {
+            encryption_key: vec![1, 2, 3],
+            hmac_key: vec![4, 5, 6],
+            blob_identifier_salt: vec![7, 8, 9],
+        };
+
+        let master_keys = keyset.to_master_keys();
+
+        assert_eq!(master_keys.len(), 3);
+        assert_eq!(master_keys[0], vec![1, 2, 3]);
+        assert_eq!(master_keys[1], vec![4, 5, 6]);
+        assert_eq!(master_keys[2], vec![7, 8, 9]);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested public function `to_master_keys` in the `EncryptedKeySet` struct within `arq7/encrypted_keyset.rs`.
📊 **Coverage:** The new test ensures that an `EncryptedKeySet` correctly converts its fields into a `Vec<Vec<u8>>` of three items with the right contents in the right order.
✨ **Result:** Test coverage improved. The test is deterministic, clean, and adds missing validation for this struct method.

---
*PR created automatically by Jules for task [8243697188347451538](https://jules.google.com/task/8243697188347451538) started by @ljen*