### PR TITLE
🧪 Add test for invalid master keys length in `from_master_keys`

### DIFF
--- a/arq/src/arq7/encrypted_keyset.rs
+++ b/arq/src/arq7/encrypted_keyset.rs
@@ -170,3 +170,29 @@ impl EncryptedKeySet {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_master_keys_invalid_length() {
+        // Test with length 2
+        let keys_2 = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let result = EncryptedKeySet::from_master_keys(keys_2);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            Error::InvalidFormat(msg) => assert_eq!(msg, "Expected 3 master keys"),
+            _ => panic!("Expected Error::InvalidFormat"),
+        }
+
+        // Test with length 4
+        let keys_4 = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9], vec![10, 11, 12]];
+        let result = EncryptedKeySet::from_master_keys(keys_4);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            Error::InvalidFormat(msg) => assert_eq!(msg, "Expected 3 master keys"),
+            _ => panic!("Expected Error::InvalidFormat"),
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify that `EncryptedKeySet::from_master_keys` correctly returns an `Error::InvalidFormat` when the provided master keys vector does not have a length of 3.
📊 **Coverage:** The test ensures the error handling path is covered by verifying that vectors of lengths 2 and 4 trigger the expected format error.
✨ **Result:** Improved test coverage and guaranteed robustness of `from_master_keys` validation logic against improperly formatted master keys vectors.

---
*PR created automatically by Jules for task [5888191473498561035](https://jules.google.com/task/5888191473498561035) started by @ljen*