### PR TITLE
🔒 Fix unsafe unwrap() in encrypted_keyset.rs

### DIFF
--- a/arq/src/arq7/encrypted_keyset.rs
+++ b/arq/src/arq7/encrypted_keyset.rs
@@ -100,7 +100,7 @@ impl EncryptedKeySet {
         let mut derived_key = vec![0u8; 64];
         ring::pbkdf2::derive(
             ring::pbkdf2::PBKDF2_HMAC_SHA256,
-            std::num::NonZeroU32::new(200_000).unwrap(),
+            std::num::NonZeroU32::new(200_000).ok_or(Error::CryptoError)?,
             &salt,
             password.as_bytes(),
             &mut derived_key,


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of an unsafe `unwrap()` call when parsing PBKDF2 rounds (`std::num::NonZeroU32::new(200_000).unwrap()`) in `encrypted_keyset.rs`.
⚠️ **Risk:** While the specific value is currently hardcoded and will not panic, using `unwrap()` directly on operations that can conceptually fail (and are flagged by security scanners and strict linting rules) is an insecure coding practice. If the code was ever modified to use a variable or configuration value instead of a hardcoded constant, this `unwrap()` could lead to a crash and potential denial-of-service (DoS) if malformed input was provided.
🛡️ **Solution:** Replaced the `unwrap()` with `ok_or(Error::CryptoError)?`. This properly propagates a specific crypto error in the event that the `NonZeroU32` creation fails, resolving the vulnerability, satisfying security lints, and establishing safer error handling patterns for the future without changing the current runtime behavior.

---
*PR created automatically by Jules for task [2202710114085080515](https://jules.google.com/task/2202710114085080515) started by @ljen*