### PR TITLE
🧪 [testing improvement] Add length check and tests for Commit::is_commit

### DIFF
--- a/arq/src/commit.rs
+++ b/arq/src/commit.rs
@@ -89,7 +89,7 @@ pub struct Commit {
 
 impl Commit {
     pub fn is_commit(content: &[u8]) -> bool {
-        content[..10] == [67, 111, 109, 109, 105, 116, 86, 48, 49, 50] // CommitV012
+        content.len() >= 10 && content[..10] == [67, 111, 109, 109, 105, 116, 86, 48, 49, 50] // CommitV012
     }
 
     pub fn new<R: ArqRead>(mut reader: R) -> Result<Commit> {
@@ -178,5 +178,22 @@ impl Commit {
             config_plist_xml,
             arq_version,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_commit() {
+        let valid_commit = b"CommitV012someotherdata";
+        assert!(Commit::is_commit(valid_commit));
+
+        let invalid_commit = b"CommitV011someotherdata";
+        assert!(!Commit::is_commit(invalid_commit));
+
+        let short_array = [0u8; 5];
+        assert!(!Commit::is_commit(&short_array));
     }
 }


### PR DESCRIPTION
🎯 **What:** The `is_commit` function in `arq/src/commit.rs` was slicing `content[..10]` without checking if the input byte slice was at least 10 bytes long. This would cause a panic when provided with a short array. This PR adds a length check before slicing and adds tests to verify the behavior.
📊 **Coverage:** Added tests for:
  - Valid commit arrays
  - Invalid commit arrays
  - Short arrays (less than 10 bytes) that previously caused a panic
✨ **Result:** Increased test coverage and improved reliability by preventing a panic on malformed or short inputs.

---
*PR created automatically by Jules for task [3579728934965243752](https://jules.google.com/task/3579728934965243752) started by @ljen*