### PR TITLE
🧹 [Extract subcommand matching from main]

### DIFF
--- a/evu/src/main.rs
+++ b/evu/src/main.rs
@@ -15,6 +15,17 @@ fn main() -> Result<(), evu::error::Error> {
 
     let version = detect_version(global_path)?;
 
+    handle_subcommand(&matches, version, global_path, global_path_str)?;
+
+    Ok(())
+}
+
+fn handle_subcommand(
+    matches: &clap::ArgMatches,
+    version: ArqVersion,
+    global_path: &Path,
+    global_path_str: &str,
+) -> Result<(), evu::error::Error> {
     match matches.subcommand() {
         ("show", Some(cmd)) => match version {
             ArqVersion::Arq5 => {


### PR DESCRIPTION
🎯 **What:** Extracted the large `match matches.subcommand()` block from the `main` function into a separate `handle_subcommand` function.
💡 **Why:** To improve code maintainability and readability by keeping the `main` function concise and delegating command dispatch logic to a dedicated handler.
✅ **Verification:** Verified changes using `git diff` and ran the full `evu` test suite (`cargo test --lib`). All tests pass and the entrypoint logic is safely encapsulated.
✨ **Result:** A cleaner `main.rs` that is easier to read and modify in the future, with no change in functionality.

---
*PR created automatically by Jules for task [13645482179474396147](https://jules.google.com/task/13645482179474396147) started by @ljen*