### PR TITLE
🔒 Fix unsafe unwrap during object encryption read

### DIFF
--- a/arq/src/object_encryption.rs
+++ b/arq/src/object_encryption.rs
@@ -281,9 +281,12 @@ impl EncryptedObject {
                 "Invalid encrypted object header: expected 'ARQO'".to_string(),
             ));
         }
-        let hmac_sha256: [u8; 32] = reader.read_bytes(32)?.try_into().unwrap();
-        let master_iv: [u8; 16] = reader.read_bytes(16)?.try_into().unwrap();
-        let encrypted_data_iv_session: [u8; 64] = reader.read_bytes(64)?.try_into().unwrap();
+        let hmac_sha256: [u8; 32] = reader.read_bytes(32)?.try_into()
+            .map_err(|_| Error::InvalidFormat("Failed to parse HMAC-SHA256: incorrect length".to_string()))?;
+        let master_iv: [u8; 16] = reader.read_bytes(16)?.try_into()
+            .map_err(|_| Error::InvalidFormat("Failed to parse master IV: incorrect length".to_string()))?;
+        let encrypted_data_iv_session: [u8; 64] = reader.read_bytes(64)?.try_into()
+            .map_err(|_| Error::InvalidFormat("Failed to parse encrypted data IV session: incorrect length".to_string()))?;
         let mut ciphertext: Vec<u8> = Vec::new();
         reader.read_to_end(&mut ciphertext)?;
 


### PR DESCRIPTION
🎯 **What:** Fixed an unsafe `.unwrap()` when reading `hmac_sha256`, `master_iv`, and `encrypted_data_iv_session` byte arrays in `arq/src/object_encryption.rs`.
⚠️ **Risk:** Using `.unwrap()` for fallible slice conversions could cause a Denial of Service (DoS) vulnerability due to the application crashing/panicking if malformed input is received or length constraints are not met.
🛡️ **Solution:** Replaced `.unwrap()` with `.map_err()` to gracefully convert parsing errors into `Error::InvalidFormat` and safely propagate them upward using the `?` operator.

---
*PR created automatically by Jules for task [7949474070716772476](https://jules.google.com/task/7949474070716772476) started by @ljen*