### PR TITLE
🧪 [testing improvement] Add test for BackupSet::is_encrypted method

### DIFF
--- a/arq/src/arq7/backup_set.rs
+++ b/arq/src/arq7/backup_set.rs
@@ -783,3 +783,20 @@ fn count_files_in_node(
     }
     Ok((file_count, total_size))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backup_set_is_encrypted() {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/arq_storage_location/D1154AC6-01EB-41FE-B115-114464350B92");
+        let mut backup_set = BackupSet::from_directory_with_password(root, Some("asdfasdf1234")).unwrap();
+
+        backup_set.backup_config.is_encrypted = true;
+        assert!(backup_set.is_encrypted());
+
+        backup_set.backup_config.is_encrypted = false;
+        assert!(!backup_set.is_encrypted());
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for the `BackupSet::is_encrypted` method in `arq/src/arq7/backup_set.rs` was addressed. This simple accessor was untested, creating a slight gap in our safety net.

📊 **Coverage:** The new test suite `tests` in `arq/src/arq7/backup_set.rs` contains `test_backup_set_is_encrypted` which successfully verifies both the positive (true) and negative (false) output paths of the `is_encrypted` function against the underlying `backup_config`.

✨ **Result:** Increased unit test coverage and confidence that this core property behaves as intended regardless of refactors.

---
*PR created automatically by Jules for task [11330862388075399261](https://jules.google.com/task/11330862388075399261) started by @ljen*