### PR TITLE
🧹 [Refactor restore_all_folder_versions in arq7_handler.rs]

### DIFF
--- a/evu/src/arq7_handler.rs
+++ b/evu/src/arq7_handler.rs
@@ -1036,122 +1036,45 @@ pub fn restore_all_folder_versions(
 
     let versions_restored_count = std::sync::atomic::AtomicUsize::new(0);
 
-    records_to_process.into_par_iter().try_for_each(|(folder_uuid, arq7_record, timestamp_str)| -> Result<()> {
-                    debug_eprintln!(
-                        "DEBUG: restore_all_folder_versions: Arq7 record timestamp: {}",
-                        timestamp_str
-                    );
-                    let record_local_path_str = arq7_record.local_path.as_deref().unwrap_or("");
-                    let mut effective_path_parts =
-                        std::borrow::Cow::Borrowed(path_parts.as_slice());
+    records_to_process.into_par_iter().try_for_each(
+        |(folder_uuid, arq7_record, timestamp_str)| -> Result<()> {
+            debug_eprintln!(
+                "DEBUG: restore_all_folder_versions: Arq7 record timestamp: {}",
+                timestamp_str
+            );
+            let record_local_path_str = arq7_record.local_path.as_deref().unwrap_or("");
+            let bf_config_local_path = backup_set
+                .backup_folder_configs
+                .get(folder_uuid)
+                .map(|bf| bf.local_path.as_str());
 
-                    if folder_path_in_backup == "/" || folder_path_in_backup.is_empty() {
-                        effective_path_parts = std::borrow::Cow::Borrowed(&[]);
-                    } else if !record_local_path_str.is_empty()
-                        && folder_path_in_backup.starts_with(record_local_path_str)
-                    {
-                        let relative_path = folder_path_in_backup
-                            .strip_prefix(record_local_path_str)
-                            .unwrap_or(folder_path_in_backup);
-                        let trimmed_relative_path = relative_path.trim_start_matches('/');
-                        let mut temp_parts: Vec<&str> = trimmed_relative_path
-                            .split('/')
-                            .filter(|s| !s.is_empty())
-                            .collect();
-                        if trimmed_relative_path.is_empty()
-                            && !relative_path.is_empty()
-                            && folder_path_in_backup != "/"
-                        {
-                            temp_parts = Vec::new();
-                        }
-                        effective_path_parts = std::borrow::Cow::Owned(temp_parts);
-                    } else if record_local_path_str.is_empty() {
-                        if let Some(bf_config) = backup_set.backup_folder_configs.get(folder_uuid) {
-                            if folder_path_in_backup.starts_with(&bf_config.local_path) {
-                                let relative_path = folder_path_in_backup
-                                    .strip_prefix(&bf_config.local_path)
-                                    .unwrap_or(folder_path_in_backup);
-                                let trimmed_relative_path = relative_path.trim_start_matches('/');
-                                let mut temp_parts: Vec<&str> = trimmed_relative_path
-                                    .split('/')
-                                    .filter(|s| !s.is_empty())
-                                    .collect();
-                                if trimmed_relative_path.is_empty()
-                                    && !relative_path.is_empty()
-                                    && folder_path_in_backup != "/"
-                                {
-                                    temp_parts = Vec::new();
-                                }
-                                effective_path_parts = std::borrow::Cow::Owned(temp_parts);
-                            }
-                        }
-                    }
+            let effective_path_parts = resolve_effective_path_parts(
+                folder_path_in_backup,
+                &path_parts,
+                record_local_path_str,
+                bf_config_local_path,
+            );
 
-                    if let Ok(Some(target_node)) = find_node_in_record_tree(
-                        &arq7_record.node,
-                        &effective_path_parts,
-                        0,
-                        backup_set_path,
-                        keyset,
-                    ) {
-                        if target_node.is_tree {
-                            let version_dest_dir_name = format!("{}", timestamp_str);
-                            let version_destination = destination_root.join(version_dest_dir_name);
-
-                            let content_dest_dir_name =
-                                effective_path_parts.last().map_or("root_content", |n| *n);
-                            let final_content_destination =
-                                version_destination.join(content_dest_dir_name);
-
-                            if !final_content_destination.exists() {
-                                std::fs::create_dir_all(&final_content_destination)?;
-                            }
-
-                            println!(
-                                "  Restoring version from record (Timestamp: {}) to {}...",
-                                timestamp_str,
-                                final_content_destination.display()
-                            );
-                            let mut stats = ExtractionStats::default();
-                            let mut ctx = ExtractionContext {
-                                backup_set_path,
-                                keyset,
-                                stats: &mut stats,
-                            };
-                            match extract_node_to_destination_recursive(
-                                &target_node,
-                                &final_content_destination,
-                                "",
-                                &mut ctx,
-                            ) {
-                                Ok(_) => {
-                                    println!(
-                                        "    Successfully restored version. Files: {}, Dirs: {}, Size: {} bytes. Errors: {}",
-                                        stats.files_restored,
-                                        stats.dirs_created,
-                                        stats.bytes_restored,
-                                        stats.errors
-                                    );
-                                    if stats.errors > 0 {
-                                        debug_eprintln!(
-                                            "    Warning: {} errors occurred during this version's restoration.",
-                                            stats.errors
-                                        );
-                                    }
-                                    versions_restored_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                }
-                                Err(e) => {
-                                    debug_eprintln!(
-                                        "    Error restoring version from record {}: {}",
-                                        timestamp_str,
-                                        e
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
-    })?;
+            if let Ok(Some(target_node)) = find_node_in_record_tree(
+                &arq7_record.node,
+                &effective_path_parts,
+                0,
+                backup_set_path,
+                keyset,
+            ) {
+                restore_version_from_record(
+                    &target_node,
+                    &effective_path_parts,
+                    &timestamp_str,
+                    destination_root,
+                    backup_set_path,
+                    keyset,
+                    &versions_restored_count,
+                )?;
+            }
+            Ok(())
+        },
+    )?;
 
     let final_count = versions_restored_count.load(std::sync::atomic::Ordering::Relaxed);
     if final_count == 0 {
@@ -1166,6 +1089,121 @@ pub fn restore_all_folder_versions(
         );
     }
 
+    Ok(())
+}
+
+fn resolve_effective_path_parts<'a>(
+    folder_path_in_backup: &'a str,
+    path_parts: &'a [&'a str],
+    record_local_path_str: &str,
+    bf_config_local_path: Option<&str>,
+) -> std::borrow::Cow<'a, [&'a str]> {
+    let mut effective_path_parts = std::borrow::Cow::Borrowed(path_parts);
+
+    if folder_path_in_backup == "/" || folder_path_in_backup.is_empty() {
+        effective_path_parts = std::borrow::Cow::Borrowed(&[][..]);
+    } else if !record_local_path_str.is_empty()
+        && folder_path_in_backup.starts_with(record_local_path_str)
+    {
+        let relative_path = folder_path_in_backup
+            .strip_prefix(record_local_path_str)
+            .unwrap_or(folder_path_in_backup);
+        let trimmed_relative_path = relative_path.trim_start_matches('/');
+        let mut temp_parts: Vec<&str> = trimmed_relative_path
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect();
+        if trimmed_relative_path.is_empty()
+            && !relative_path.is_empty()
+            && folder_path_in_backup != "/"
+        {
+            temp_parts = Vec::new();
+        }
+        effective_path_parts = std::borrow::Cow::Owned(temp_parts);
+    } else if record_local_path_str.is_empty() {
+        if let Some(local_path) = bf_config_local_path {
+            if folder_path_in_backup.starts_with(local_path) {
+                let relative_path = folder_path_in_backup
+                    .strip_prefix(local_path)
+                    .unwrap_or(folder_path_in_backup);
+                let trimmed_relative_path = relative_path.trim_start_matches('/');
+                let mut temp_parts: Vec<&str> = trimmed_relative_path
+                    .split('/')
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                if trimmed_relative_path.is_empty()
+                    && !relative_path.is_empty()
+                    && folder_path_in_backup != "/"
+                {
+                    temp_parts = Vec::new();
+                }
+                effective_path_parts = std::borrow::Cow::Owned(temp_parts);
+            }
+        }
+    }
+
+    effective_path_parts
+}
+
+fn restore_version_from_record(
+    target_node: &Node,
+    effective_path_parts: &[&str],
+    timestamp_str: &str,
+    destination_root: &Path,
+    backup_set_path: &Path,
+    keyset: Option<&EncryptedKeySet>,
+    versions_restored_count: &std::sync::atomic::AtomicUsize,
+) -> Result<()> {
+    if target_node.is_tree {
+        let version_dest_dir_name = format!("{}", timestamp_str);
+        let version_destination = destination_root.join(version_dest_dir_name);
+
+        let content_dest_dir_name = effective_path_parts.last().map_or("root_content", |n| *n);
+        let final_content_destination = version_destination.join(content_dest_dir_name);
+
+        if !final_content_destination.exists() {
+            std::fs::create_dir_all(&final_content_destination)?;
+        }
+
+        println!(
+            "  Restoring version from record (Timestamp: {}) to {}...",
+            timestamp_str,
+            final_content_destination.display()
+        );
+        let mut stats = ExtractionStats::default();
+        let mut ctx = ExtractionContext {
+            backup_set_path,
+            keyset,
+            stats: &mut stats,
+        };
+        match extract_node_to_destination_recursive(
+            target_node,
+            &final_content_destination,
+            "",
+            &mut ctx,
+        ) {
+            Ok(_) => {
+                println!(
+                    "    Successfully restored version. Files: {}, Dirs: {}, Size: {} bytes. Errors: {}",
+                    stats.files_restored, stats.dirs_created, stats.bytes_restored, stats.errors
+                );
+                if stats.errors > 0 {
+                    debug_eprintln!(
+                        "    Warning: {} errors occurred during this version's restoration.",
+                        stats.errors
+                    );
+                }
+                versions_restored_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            Err(e) => {
+                debug_eprintln!(
+                    "    Error restoring version from record {}: {}",
+                    timestamp_str,
+                    e
+                );
+            }
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
🎯 **What:** Extracted `resolve_effective_path_parts` and `restore_version_from_record` functions to break down the complex `restore_all_folder_versions` function.
💡 **Why:** To improve the maintainability, testability, and readability of the codebase by moving chunks of independent logic into specialized helper functions.
✅ **Verification:** Ran `cargo test --lib` and `cargo check` to ensure correctness and stability of the changes.
✨ **Result:** A cleaner, more modular `arq7_handler.rs` implementation that is easier to maintain.

---
*PR created automatically by Jules for task [15340831865522082206](https://jules.google.com/task/15340831865522082206) started by @ljen*