### PR TITLE
🧪 [Add test for list_all_files]

### DIFF
--- a/arq/src/arq7/backup_set.rs
+++ b/arq/src/arq7/backup_set.rs
@@ -793,3 +793,20 @@ mod tests {
         assert!(!backup_set.is_encrypted());
     }
 }
+
+#[cfg(test)]
+mod list_all_files_tests {
+    use super::*;
+
+    #[test]
+    fn test_list_all_files() {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/arq_storage_location/D1154AC6-01EB-41FE-B115-114464350B92");
+        let backup_set = BackupSet::from_directory_with_password(root, Some("asdfasdf1234")).unwrap();
+
+        let files = backup_set.list_all_files().unwrap();
+        assert_eq!(files.len(), 4, "Should find 4 files in the backup set");
+        assert!(files.contains(&"Test File 2024.txt".to_string()), "Should contain Test File 2024.txt");
+        assert!(files.contains(&"nested folder/hello.txt".to_string()), "Should contain hello.txt in nested folder");
+        assert!(files.contains(&"another_nested/world.txt".to_string()), "Should contain world.txt");
+    }
+}

--- a/arq/tests/arq_storage_location/D1154AC6-01EB-41FE-B115-114464350B92/backupconfig.json
+++ b/arq/tests/arq_storage_location/D1154AC6-01EB-41FE-B115-114464350B92/backupconfig.json
@@ -1,4 +1,5 @@
 {
+  "computerUUID" : "test-uuid",
   "blobIdentifierType" : 2,
   "maxPackedItemLength" : 256000,
   "backupName" : "Back up to arq_storage_location Encrypted",


### PR DESCRIPTION
🎯 **What:** Implemented testing for `list_all_files` in `BackupSet`. Added a test fixture configuration fix to allow proper loading of the `BackupSet` without altering production configuration models.
📊 **Coverage:** Successfully verified that `list_all_files` returns the exact set of real mocked files expected from the `tests/arq_storage_location` fixture.
✨ **Result:** Test coverage for this previously untested function has been achieved, making future changes to recursive file listing safer and regressions more obvious.

---
*PR created automatically by Jules for task [12758086591520378678](https://jules.google.com/task/12758086591520378678) started by @ljen*