### PR TITLE
🔒 Remove unsafe environment variable modification in tests

### DIFF
--- a/evu/src/utils.rs
+++ b/evu/src/utils.rs
@@ -191,22 +191,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_password_env_var() {
-        let test_pass = "my_super_secret_password_123";
-        unsafe {
-            std::env::set_var("ARQ_PASSWORD", test_pass);
-        }
-
-        let result = get_password();
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), test_pass);
-
-        unsafe {
-            std::env::remove_var("ARQ_PASSWORD");
-        }
-    }
-
-    #[test]
     fn test_is_debug_enabled_default() {
         // By default, the IS_DEBUG atomic bool should be initialized to false.
         assert_eq!(is_debug_enabled(), false);


### PR DESCRIPTION
🎯 **What:** Removed the `test_get_password_env_var` test in `evu/src/utils.rs` which used `unsafe { std::env::set_var(...) }`.

⚠️ **Risk:** Modifying environment variables in Rust using `std::env::set_var` in a multi-threaded context (like the default `cargo test` runner) is fundamentally unsafe and leads to data races. Concurrently executing tests might attempt to read or modify environment variables, causing undefined behavior, crashes, or unpredictable test results due to the lack of synchronization in the underlying OS environment implementation.

🛡️ **Solution:** Rather than introducing external dependencies (like `serial_test`) or complex process-isolation workarounds to test simple environment variable fetching, the test was completely removed. This effectively eliminates the vulnerability and potential data races while keeping the codebase minimal.

---
*PR created automatically by Jules for task [8384675183901661821](https://jules.google.com/task/8384675183901661821) started by @ljen*