### PR TITLE
🔒 Fix unsafe unwrap on network bindings in main

### DIFF
--- a/web-ui/src/main.rs
+++ b/web-ui/src/main.rs
@@ -423,7 +423,7 @@ fn format_timestamp_rfc3339(ts_f64: f64) -> String {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> std::io::Result<()> {
     let state = AppState {
         backup_set: Arc::new(Mutex::new(None)),
     };
@@ -437,7 +437,9 @@ async fn main() {
         .route("/api/record/:record_id/download", get(download_file))
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await.unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
     println!("Listening on http://127.0.0.1:3000");
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await?;
+
+    Ok(())
 }


### PR DESCRIPTION
🎯 **What:** Replaced unsafe `.unwrap()` calls on network bindings and server initialization in `web-ui/src/main.rs` with the `?` operator, properly returning a `std::io::Result<()>`.

⚠️ **Risk:** If the port (e.g., `3000`) is already in use or cannot be bound, the application would abruptly panic (`unwrap()`) and crash unceremoniously, preventing graceful error handling or logging by the caller/supervisor. This constitutes an unhandled exception vulnerability for the application.

🛡️ **Solution:** Changed the signature of `main` to `async fn main() -> std::io::Result<()>` and used `?` to bubble up I/O errors from `TcpListener::bind` and `axum::serve`. The application now exits cleanly with an informative error rather than a panic.

---
*PR created automatically by Jules for task [5117083545066798967](https://jules.google.com/task/5117083545066798967) started by @ljen*