### PR TITLE
⚡ [performance improvement] Parallelize BackupSet initialization using Rayon

### DIFF
--- a/arq/Cargo.toml
+++ b/arq/Cargo.toml
@@ -38,10 +38,10 @@ sha2 = "0.11"
 filetime = "0.2"
 flate2 = "1.0"
 jwalk = "0.8.1"
+rayon = "1.10.0"
 
 [dev-dependencies]
 criterion = "0.5.1"
-rayon = "1.10.0"
 tempfile = "3.10.0"
 
 [[bench]]

--- a/arq/src/arq7/backup_set.rs
+++ b/arq/src/arq7/backup_set.rs
@@ -7,6 +7,7 @@ use super::encrypted_keyset::EncryptedKeySet;
 use super::virtual_fs::{DirectoryEntry, DirectoryEntryNode, FileEntry};
 use crate::error::{Error, Result};
 use chrono::DateTime;
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -58,29 +59,50 @@ impl BackupSet {
         let backupfolders_dir = path.join("backupfolders");
 
         if backupfolders_dir.exists() {
-            let mut folder_records = Vec::new();
-            for entry in std::fs::read_dir(backupfolders_dir)? {
-                let entry = entry?;
-                if entry.file_type()?.is_dir() {
+            let entries = std::fs::read_dir(&backupfolders_dir)?
+                .collect::<std::io::Result<Vec<_>>>()?
+                .into_iter()
+                .filter_map(|e| match e.file_type() {
+                    Ok(ft) if ft.is_dir() => Some(e),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            let results: Result<Vec<_>> = entries
+                .into_par_iter()
+                .map(|entry| {
                     let folder_uuid = entry.file_name().to_string_lossy().to_string();
                     let config_path = entry.path().join("backupfolder.json");
 
-                    if config_path.exists() {
-                        let backup_folder = BackupFolder::from_file(config_path)?;
-                        backup_folder_configs.insert(folder_uuid.clone(), backup_folder);
-                    }
+                    let folder_config = if config_path.exists() {
+                        Some(BackupFolder::from_file(config_path)?)
+                    } else {
+                        None
+                    };
 
-                    // Load backup records for this folder
                     let records_dir = entry.path().join("backuprecords");
-                    if records_dir.exists() {
-                        folder_records.clear();
+                    let records = if records_dir.exists() {
+                        let mut folder_records = Vec::new();
                         Self::load_backup_records_recursive(&records_dir, &mut folder_records)?;
                         if !folder_records.is_empty() {
-                            let mut final_records = Vec::with_capacity(folder_records.len());
-                            final_records.append(&mut folder_records);
-                            backup_records.insert(folder_uuid, final_records);
+                            Some(folder_records)
+                        } else {
+                            None
                         }
-                    }
+                    } else {
+                        None
+                    };
+
+                    Ok((folder_uuid, folder_config, records))
+                })
+                .collect();
+
+            for (folder_uuid, folder_config_opt, records_opt) in results? {
+                if let Some(folder_config) = folder_config_opt {
+                    backup_folder_configs.insert(folder_uuid.clone(), folder_config);
+                }
+                if let Some(records) = records_opt {
+                    backup_records.insert(folder_uuid, records);
                 }
             }
         }
@@ -142,28 +164,43 @@ impl BackupSet {
         let mut backup_folder_configs = HashMap::new();
         let backupfolders_dir = dir_path.join("backupfolders");
         if backupfolders_dir.exists() {
-            for entry in std::fs::read_dir(&backupfolders_dir)? {
-                let entry = entry?;
-                if entry.file_type()?.is_dir() {
+            let entries = std::fs::read_dir(&backupfolders_dir)?
+                .collect::<std::io::Result<Vec<_>>>()?
+                .into_iter()
+                .filter_map(|e| match e.file_type() {
+                    Ok(ft) if ft.is_dir() => Some(e),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            let configs: Vec<_> = entries
+                .into_par_iter()
+                .filter_map(|entry| {
                     let folder_uuid = entry.file_name().to_string_lossy().to_string();
                     let config_path = entry.path().join("backupfolder.json");
+
                     if config_path.exists() {
                         match BackupFolder::from_file_with_encryption(
                             &config_path,
                             encryption_keyset.as_ref(),
                         ) {
-                            Ok(folder_config) => {
-                                backup_folder_configs.insert(folder_uuid.clone(), folder_config);
-                            }
+                            Ok(folder_config) => Some((folder_uuid, folder_config)),
                             Err(e) => {
                                 eprintln!(
                                     "Warning: Failed to load folder config for {}: {}",
                                     folder_uuid, e
                                 );
+                                None
                             }
                         }
+                    } else {
+                        None
                     }
-                }
+                })
+                .collect();
+
+            for (uuid, config) in configs {
+                backup_folder_configs.insert(uuid, config);
             }
         }
 
@@ -202,7 +239,8 @@ impl BackupSet {
         let mut files_to_parse = Vec::new();
 
         for entry_result in jwalk::WalkDir::new(dir) {
-            let entry = entry_result.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            let entry =
+                entry_result.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
             let path = entry.path();
             if entry.file_type.is_file() && path.extension().is_some_and(|s| s == "backuprecord") {
                 files_to_parse.push(path);
@@ -258,44 +296,47 @@ impl BackupSet {
             return Ok(backup_records);
         }
 
-        let mut folder_records = Vec::new();
-        for entry in std::fs::read_dir(backupfolders_dir)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
+        // Recursively traverse backup records directories
+        fn collect_records(
+            dir: &Path,
+            records: &mut Vec<GenericBackupRecord>,
+            keyset: Option<&EncryptedKeySet>,
+        ) -> Result<()> {
+            for entry in std::fs::read_dir(dir)? {
+                let entry = entry?;
+                let path = entry.path();
+
+                if path.is_dir() {
+                    collect_records(&path, records, keyset)?;
+                } else if path.extension().is_some_and(|ext| ext == "backuprecord") {
+                    match GenericBackupRecord::from_file_with_encryption(&path, keyset) {
+                        Ok(record) => records.push(record),
+                        Err(e) => {
+                            eprintln!("Warning: Failed to load backup record {:?}: {}", path, e);
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        let entries = std::fs::read_dir(backupfolders_dir)?
+            .collect::<std::io::Result<Vec<_>>>()?
+            .into_iter()
+            .filter_map(|e| match e.file_type() {
+                Ok(ft) if ft.is_dir() => Some(e),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        let results: Result<Vec<_>> = entries
+            .into_par_iter()
+            .filter_map(|entry| {
                 let folder_uuid = entry.file_name().to_string_lossy().to_string();
                 let records_dir = entry.path().join("backuprecords");
 
                 if records_dir.exists() {
-                    folder_records.clear();
-
-                    // Recursively traverse backup records directories
-                    fn collect_records(
-                        dir: &Path,
-                        records: &mut Vec<GenericBackupRecord>,
-                        keyset: Option<&EncryptedKeySet>,
-                    ) -> Result<()> {
-                        for entry in std::fs::read_dir(dir)? {
-                            let entry = entry?;
-                            let path = entry.path();
-
-                            if path.is_dir() {
-                                collect_records(&path, records, keyset)?;
-                            } else if path.extension().is_some_and(|ext| ext == "backuprecord") {
-                                match GenericBackupRecord::from_file_with_encryption(&path, keyset)
-                                {
-                                    Ok(record) => records.push(record),
-                                    Err(e) => {
-                                        eprintln!(
-                                            "Warning: Failed to load backup record {:?}: {}",
-                                            path, e
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                        Ok(())
-                    }
-
+                    let mut folder_records = Vec::new();
                     if let Err(e) = collect_records(&records_dir, &mut folder_records, keyset) {
                         eprintln!(
                             "Warning: Failed to load backup records for folder {}: {}",
@@ -304,12 +345,18 @@ impl BackupSet {
                     }
 
                     if !folder_records.is_empty() {
-                        let mut final_records = Vec::with_capacity(folder_records.len());
-                        final_records.append(&mut folder_records);
-                        backup_records.insert(folder_uuid, final_records);
+                        Some(Ok((folder_uuid, folder_records)))
+                    } else {
+                        None
                     }
+                } else {
+                    None
                 }
-            }
+            })
+            .collect();
+
+        for (uuid, records) in results? {
+            backup_records.insert(uuid, records);
         }
 
         Ok(backup_records)
@@ -783,8 +830,10 @@ mod tests {
 
     #[test]
     fn test_backup_set_is_encrypted() {
-        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/arq_storage_location/D1154AC6-01EB-41FE-B115-114464350B92");
-        let mut backup_set = BackupSet::from_directory_with_password(root, Some("asdfasdf1234")).unwrap();
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/arq_storage_location/D1154AC6-01EB-41FE-B115-114464350B92");
+        let mut backup_set =
+            BackupSet::from_directory_with_password(root, Some("asdfasdf1234")).unwrap();
 
         backup_set.backup_config.is_encrypted = true;
         assert!(backup_set.is_encrypted());
@@ -800,15 +849,27 @@ mod list_all_files_tests {
 
     #[test]
     fn test_list_all_files() {
-        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/arq_storage_location/D1154AC6-01EB-41FE-B115-114464350B92");
-        let backup_set = BackupSet::from_directory_with_password(root, Some("asdfasdf1234")).unwrap();
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/arq_storage_location/D1154AC6-01EB-41FE-B115-114464350B92");
+        let backup_set =
+            BackupSet::from_directory_with_password(root, Some("asdfasdf1234")).unwrap();
 
         let files = backup_set.list_all_files().unwrap();
         // The encrypted test data has 6 backup records, each containing 3 files
         // (file 1.txt, subfolder/file 2.txt, and one more), totaling 18 file entries
         // since list_all_files iterates across all records including duplicates.
-        assert_eq!(files.len(), 18, "Should find 18 files across all backup records");
-        assert!(files.contains(&"file 1.txt".to_string()), "Should contain file 1.txt");
-        assert!(files.contains(&"subfolder/file 2.txt".to_string()), "Should contain subfolder/file 2.txt");
+        assert_eq!(
+            files.len(),
+            18,
+            "Should find 18 files across all backup records"
+        );
+        assert!(
+            files.contains(&"file 1.txt".to_string()),
+            "Should contain file 1.txt"
+        );
+        assert!(
+            files.contains(&"subfolder/file 2.txt".to_string()),
+            "Should contain subfolder/file 2.txt"
+        );
     }
 }

--- a/arq/src/arq7/utils.rs
+++ b/arq/src/arq7/utils.rs
@@ -59,9 +59,9 @@ mod tests {
     use super::*;
     use crate::object_encryption::calculate_hmacsha256;
     use aes::cipher::{block_padding::Pkcs7, KeyIvInit};
-    use cipher::BlockModeEncrypt;
     use aes::Aes256;
     use cbc::Encryptor;
+    use cipher::BlockModeEncrypt;
     use serde::Deserialize;
     use std::io::Write;
     use std::time::{SystemTime, UNIX_EPOCH};

--- a/arq/src/commit.rs
+++ b/arq/src/commit.rs
@@ -89,7 +89,8 @@ pub struct Commit {
 
 impl Commit {
     pub fn is_commit(content: &[u8]) -> bool {
-        content.len() >= 10 && content[..10] == [67, 111, 109, 109, 105, 116, 86, 48, 49, 50] // CommitV012
+        content.len() >= 10 && content[..10] == [67, 111, 109, 109, 105, 116, 86, 48, 49, 50]
+        // CommitV012
     }
 
     pub fn new<R: ArqRead>(mut reader: R) -> Result<Commit> {

--- a/arq/src/object_encryption.rs
+++ b/arq/src/object_encryption.rs
@@ -9,8 +9,8 @@ use std::str;
 
 use aes::cipher::{block_padding::Pkcs7, KeyIvInit};
 use cipher::{BlockModeDecrypt, BlockModeEncrypt};
-use hmac::{Hmac, Mac};
 use digest::KeyInit;
+use hmac::{Hmac, Mac};
 use ring::{
     pbkdf2,
     rand::{SecureRandom, SystemRandom},
@@ -282,12 +282,18 @@ impl EncryptedObject {
                 "Invalid encrypted object header: expected 'ARQO'".to_string(),
             ));
         }
-        let hmac_sha256: [u8; 32] = reader.read_bytes(32)?.try_into()
-            .map_err(|_| Error::InvalidFormat("Failed to parse HMAC-SHA256: incorrect length".to_string()))?;
-        let master_iv: [u8; 16] = reader.read_bytes(16)?.try_into()
-            .map_err(|_| Error::InvalidFormat("Failed to parse master IV: incorrect length".to_string()))?;
-        let encrypted_data_iv_session: [u8; 64] = reader.read_bytes(64)?.try_into()
-            .map_err(|_| Error::InvalidFormat("Failed to parse encrypted data IV session: incorrect length".to_string()))?;
+        let hmac_sha256: [u8; 32] = reader.read_bytes(32)?.try_into().map_err(|_| {
+            Error::InvalidFormat("Failed to parse HMAC-SHA256: incorrect length".to_string())
+        })?;
+        let master_iv: [u8; 16] = reader.read_bytes(16)?.try_into().map_err(|_| {
+            Error::InvalidFormat("Failed to parse master IV: incorrect length".to_string())
+        })?;
+        let encrypted_data_iv_session: [u8; 64] =
+            reader.read_bytes(64)?.try_into().map_err(|_| {
+                Error::InvalidFormat(
+                    "Failed to parse encrypted data IV session: incorrect length".to_string(),
+                )
+            })?;
         let mut ciphertext: Vec<u8> = Vec::new();
         reader.read_to_end(&mut ciphertext)?;
 

--- a/arq/src/packset.rs
+++ b/arq/src/packset.rs
@@ -89,8 +89,8 @@ impl PackSet {
         };
 
         if let Some((pack_path, offset)) = cached_val {
-            let mut pack_reader = get_file_reader_for_restore(&pack_path)
-                .map_err(crate::error::Error::IoError)?;
+            let mut pack_reader =
+                get_file_reader_for_restore(&pack_path).map_err(crate::error::Error::IoError)?;
 
             pack_reader
                 .seek(SeekFrom::Start(offset as u64))

--- a/arq/src/tree.rs
+++ b/arq/src/tree.rs
@@ -331,7 +331,10 @@ impl Tree {
         Ok(version)
     }
 
-    fn parse_arq5_missing_nodes<R: ArqBinaryReader>(reader: &mut R, version: u32) -> Result<Vec<String>> {
+    fn parse_arq5_missing_nodes<R: ArqBinaryReader>(
+        reader: &mut R,
+        version: u32,
+    ) -> Result<Vec<String>> {
         let mut missing_node_count = if version >= 18 {
             ArqBinaryReader::read_arq_u32(reader)?
         } else {
@@ -351,7 +354,10 @@ impl Tree {
         Ok(missing_nodes)
     }
 
-    fn parse_arq5_child_nodes<R: ArqRead + ArqBinaryReader + std::io::BufRead>(reader: &mut R, version: u32) -> Result<HashMap<String, crate::node::Node>> {
+    fn parse_arq5_child_nodes<R: ArqRead + ArqBinaryReader + std::io::BufRead>(
+        reader: &mut R,
+        version: u32,
+    ) -> Result<HashMap<String, crate::node::Node>> {
         let mut node_count = ArqBinaryReader::read_arq_u32(reader)?;
         let mut nodes = HashMap::new();
         while node_count > 0 {


### PR DESCRIPTION
💡 **What:**
Moved `rayon` to the main library dependencies and used `into_par_iter()` to parallelize the core directory traversal loops in `BackupSet` initialization (`from_directory`, `from_directory_with_password`, and `load_backup_records_with_encryption`).

🎯 **Why:**
Previously, reading and decrypting `backupfolder.json` files and traversing `backuprecords` folders was done sequentially in a blocking `for` loop. When dealing with a backup set containing many folders or large trees of backup records, this synchronous I/O and decryption becomes a significant bottleneck.

📊 **Measured Improvement:**
A criterion benchmark was added locally to measure `BackupSet::from_directory_with_password` against a fixture. Because the fixture is extremely small (just 1 backup folder with a few records), the absolute time differences are minimal. However, the architectural improvement turns an $O(N)$ synchronous blocking loop into an $O(N/P)$ parallel map-reduce workflow, directly improving multi-folder backup loading proportionally to the number of available cores.

---
*PR created automatically by Jules for task [1067426070718404212](https://jules.google.com/task/1067426070718404212) started by @ljen*