### PR TITLE
🧹 Remove empty `Ok(Some(_node_cow))` match arm

### DIFF
--- a/evu/src/arq7_handler.rs
+++ b/evu/src/arq7_handler.rs
@@ -668,8 +668,7 @@ fn list_versions_internal(
                             }
                             found = true;
                         }
-                        Ok(Some(_node_cow)) => {}
-                        Ok(None) => {}
+                        Ok(_) => {}
                         Err(e) => {
                             output_lines.push(format!(
                                 "DEBUG: Warning: Error processing Arq7 record {:?}: {}",


### PR DESCRIPTION
🎯 **What:** Replaced the empty `Ok(Some(_node_cow))` and `Ok(None)` match arms in `evu/src/arq7_handler.rs` with a single `Ok(_) => {}` catch-all.
💡 **Why:** This removes an unnecessary empty match arm that was doing nothing except capturing a variable just to ignore it (`_node_cow`), and consolidates multiple empty paths into one catch-all path. This slightly improves code readability and maintainability by keeping the logic clean and removing clutter.
✅ **Verification:** Ran `cargo check` and `cargo test --lib` inside the `evu` crate to verify no breaking changes were introduced and that all tests still pass.
✨ **Result:** Cleaned up and slightly simplified the pattern matching block in `find_node_in_record_tree` handler logic.

---
*PR created automatically by Jules for task [17388910348884380100](https://jules.google.com/task/17388910348884380100) started by @ljen*