### PR TITLE
🧹 [code health improvement] Remove unused buffer allocation

### DIFF
--- a/arq/src/packset.rs
+++ b/arq/src/packset.rs
@@ -321,7 +321,7 @@ impl PackIndex {
         // "cursor"/reader. So what I do is I try to read 21 bytes. If I can, then I know
         // I have more than just the sha1 of the content. If I can't, then I'm back where
         // I was and I do nothing.
-        let mut _buf = vec![0; 21];
+        let mut _buf = [0u8; 21];
         if reader.read_exact(&mut _buf).is_ok() {
             // This is a easier condition than trying to read the bytes for glacier.  If all
             // the bytes read + 20 (for the final sha1) account for the entire length of the


### PR DESCRIPTION
🎯 **What:** Replaced the unused heap-allocated `vec![0; 21]` buffer with a stack-allocated `[0u8; 21]` byte array in `arq/src/packset.rs`.
💡 **Why:** To improve code health and performance by removing a completely unnecessary heap allocation, while correctly maintaining the required side effect of advancing the reader position.
✅ **Verification:** Ran `cargo check` and `cargo test --lib` within the `arq` crate. All tests passed, confirming no regressions. 
✨ **Result:** The code is cleaner, marginally faster due to zero heap allocation, and functions exactly as before.

---
*PR created automatically by Jules for task [13013590418867267920](https://jules.google.com/task/13013590418867267920) started by @ljen*