### PR TITLE
🧪 [testing improvement] Assert specific error message for unsupported compression type

### DIFF
--- a/arq/src/blob_location.rs
+++ b/arq/src/blob_location.rs
@@ -572,10 +572,12 @@ mod tests {
 
     #[test]
     fn decompress_data_unsupported_type() {
-        let loc = create_test_blobloc(3);
+        let loc = create_test_blobloc(99);
         let data = b"hello world".to_vec();
         let result = loc.decompress_data(data);
-        assert!(matches!(result, Err(Error::InvalidFormat(_))));
+        assert!(
+            matches!(result, Err(Error::InvalidFormat(msg)) if msg == "Unsupported compression type: 99")
+        );
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** The `decompress_data` method was tested for unsupported compression type, but it wasn't asserting that the error explicitly had the correct message `"Unsupported compression type: 99"`.
📊 **Coverage:** Tests now verify not only that an `InvalidFormat` error is returned for an unsupported compression type (using `99`), but also that the error's inner message specifically describes the compression type passed in.
✨ **Result:** Improved test precision and rigor. Tests are no longer passing solely by checking the error type but validating the entire error state.

---
*PR created automatically by Jules for task [8371781447141016446](https://jules.google.com/task/8371781447141016446) started by @ljen*