### PR TITLE
🧹 [Refactor `web-ui` route handlers to use common helper]

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,104 @@
+--- web-ui/src/main.rs
++++ web-ui/src/main.rs
+@@ -159,19 +159,25 @@
+     None
+ }
+
++async fn get_bs_and_node(
++    state: &AppState,
++    record_id: &str,
++) -> Result<(Arc<BackupSet>, Node), axum::response::Response> {
++    let bs_lock = state.backup_set.lock().await;
++    let bs = match bs_lock.as_ref() {
++        Some(b) => Arc::clone(b),
++        None => return Err((StatusCode::BAD_REQUEST, "Not loaded").into_response()),
++    };
++
++    let record = match get_arq7_record(&bs, record_id) {
++        Some(r) => r,
++        None => return Err((StatusCode::NOT_FOUND, "Record not found").into_response()),
++    };
++
++    Ok((bs, record.node.clone()))
++}
++
+ async fn get_tree(
+     State(state): State<AppState>,
+     AxumPath(record_id): AxumPath<String>,
+     Query(query): Query<TreeQuery>,
+ ) -> impl IntoResponse {
+-    let bs_lock = state.backup_set.lock().await;
+-    let bs = match bs_lock.as_ref() {
+-        Some(b) => b,
+-        None => return (StatusCode::BAD_REQUEST, "Not loaded").into_response(),
+-    };
+-
+-    let record = match get_arq7_record(bs, &record_id) {
+-        Some(r) => r,
+-        None => return (StatusCode::NOT_FOUND, "Record not found").into_response(),
+-    };
++    let (bs_clone, root_node) = match get_bs_and_node(&state, &record_id).await {
++        Ok(res) => res,
++        Err(resp) => return resp,
++    };
+
+     // Resolve the path
+     let req_path = query.path.unwrap_or_default();
+-
+-    let bs_clone = Arc::clone(bs);
+-    let root_node = record.node.clone();
+
+     let result = tokio::task::spawn_blocking(move || {
+@@ -208,22 +214,13 @@
+     AxumPath(record_id): AxumPath<String>,
+     Query(query): Query<TreeQuery>,
+ ) -> impl IntoResponse {
+-    let bs_lock = state.backup_set.lock().await;
+-    let bs = match bs_lock.as_ref() {
+-        Some(b) => b,
+-        None => return (StatusCode::BAD_REQUEST, "Not loaded").into_response(),
+-    };
+-
+-    let record = match get_arq7_record(bs, &record_id) {
+-        Some(r) => r,
+-        None => return (StatusCode::NOT_FOUND, "Record not found").into_response(),
+-    };
++    let (bs_clone, root_node) = match get_bs_and_node(&state, &record_id).await {
++        Ok(res) => res,
++        Err(resp) => return resp,
++    };
+
+     let req_path = query.path.unwrap_or_default();
+-    let bs_clone = Arc::clone(bs);
+-    let root_node = record.node.clone();
+
+     let result = tokio::task::spawn_blocking(move || {
+@@ -250,15 +247,10 @@
+     AxumPath(record_id): AxumPath<String>,
+     Query(query): Query<TreeQuery>,
+ ) -> impl IntoResponse {
+-    let bs_lock = state.backup_set.lock().await;
+-    let bs = match bs_lock.as_ref() {
+-        Some(b) => b,
+-        None => return (StatusCode::BAD_REQUEST, "Not loaded").into_response(),
+-    };
+-
+-    let record = match get_arq7_record(bs, &record_id) {
+-        Some(r) => r,
+-        None => return (StatusCode::NOT_FOUND, "Record not found").into_response(),
+-    };
++    let (bs_clone, root_node) = match get_bs_and_node(&state, &record_id).await {
++        Ok(res) => res,
++        Err(resp) => return resp,
++    };
+
+     // Resolve the path
+@@ -266,9 +258,6 @@
+         Some(ref p) if !p.is_empty() => p.clone(),
+         _ => return (StatusCode::BAD_REQUEST, "Path is required").into_response(),
+     };
+-
+-    let bs_clone = Arc::clone(bs);
+-    let root_node = record.node.clone();
+
+     let result = tokio::task::spawn_blocking(move || {

--- a/web-ui/src/main.rs
+++ b/web-ui/src/main.rs
@@ -159,27 +159,36 @@ fn get_arq7_record<'a>(bs: &'a BackupSet, record_id: &str) -> Option<&'a arq::ar
     None
 }
 
+async fn get_bs_and_node(
+    state: &AppState,
+    record_id: &str,
+) -> Result<(Arc<BackupSet>, Node), axum::response::Response> {
+    let bs_lock = state.backup_set.lock().await;
+    let bs = match bs_lock.as_ref() {
+        Some(b) => Arc::clone(b),
+        None => return Err((StatusCode::BAD_REQUEST, "Not loaded").into_response()),
+    };
+
+    let node = match get_arq7_record(&bs, record_id) {
+        Some(r) => r.node.clone(),
+        None => return Err((StatusCode::NOT_FOUND, "Record not found").into_response()),
+    };
+
+    Ok((bs, node))
+}
+
 async fn get_tree(
     State(state): State<AppState>,
     AxumPath(record_id): AxumPath<String>,
     Query(query): Query<TreeQuery>,
 ) -> impl IntoResponse {
-    let bs_lock = state.backup_set.lock().await;
-    let bs = match bs_lock.as_ref() {
-        Some(b) => b,
-        None => return (StatusCode::BAD_REQUEST, "Not loaded").into_response(),
-    };
-
-    let record = match get_arq7_record(bs, &record_id) {
-        Some(r) => r,
-        None => return (StatusCode::NOT_FOUND, "Record not found").into_response(),
+    let (bs_clone, root_node) = match get_bs_and_node(&state, &record_id).await {
+        Ok(res) => res,
+        Err(resp) => return resp,
     };
 
     // Resolve the path
     let req_path = query.path.unwrap_or_default();
-
-    let bs_clone = Arc::clone(bs);
-    let root_node = record.node.clone();
 
     let result = tokio::task::spawn_blocking(move || {
         let keyset = bs_clone.encryption_keyset();
@@ -208,20 +217,12 @@ async fn get_tree_dirs(
     AxumPath(record_id): AxumPath<String>,
     Query(query): Query<TreeQuery>,
 ) -> impl IntoResponse {
-    let bs_lock = state.backup_set.lock().await;
-    let bs = match bs_lock.as_ref() {
-        Some(b) => b,
-        None => return (StatusCode::BAD_REQUEST, "Not loaded").into_response(),
-    };
-
-    let record = match get_arq7_record(bs, &record_id) {
-        Some(r) => r,
-        None => return (StatusCode::NOT_FOUND, "Record not found").into_response(),
+    let (bs_clone, root_node) = match get_bs_and_node(&state, &record_id).await {
+        Ok(res) => res,
+        Err(resp) => return resp,
     };
 
     let req_path = query.path.unwrap_or_default();
-    let bs_clone = Arc::clone(bs);
-    let root_node = record.node.clone();
 
     let result = tokio::task::spawn_blocking(move || {
         let keyset = bs_clone.encryption_keyset();
@@ -250,15 +251,9 @@ async fn download_file(
     AxumPath(record_id): AxumPath<String>,
     Query(query): Query<TreeQuery>,
 ) -> impl IntoResponse {
-    let bs_lock = state.backup_set.lock().await;
-    let bs = match bs_lock.as_ref() {
-        Some(b) => b,
-        None => return (StatusCode::BAD_REQUEST, "Not loaded").into_response(),
-    };
-
-    let record = match get_arq7_record(bs, &record_id) {
-        Some(r) => r,
-        None => return (StatusCode::NOT_FOUND, "Record not found").into_response(),
+    let (bs_clone, root_node) = match get_bs_and_node(&state, &record_id).await {
+        Ok(res) => res,
+        Err(resp) => return resp,
     };
 
     // Resolve the path
@@ -266,9 +261,6 @@ async fn download_file(
         Some(ref p) if !p.is_empty() => p.clone(),
         _ => return (StatusCode::BAD_REQUEST, "Path is required").into_response(),
     };
-
-    let bs_clone = Arc::clone(bs);
-    let root_node = record.node.clone();
 
     let result = tokio::task::spawn_blocking(move || {
         let keyset = bs_clone.encryption_keyset();


### PR DESCRIPTION
🎯 **What:** Extracted duplicated `state.backup_set.lock().await` and `get_arq7_record` logic from `get_tree`, `get_tree_dirs`, and `download_file` handlers in `web-ui/src/main.rs` into a new helper function `get_bs_and_node`.
💡 **Why:** This reduces code duplication, improving maintainability and readability across the API route handlers.
✅ **Verification:** Verified by compiling the `web-ui` crate and running tests (`cargo check`, `cargo test`) for `web-ui`, `arq`, and `evu`. The changes preserve existing logic and error code semantics exactly.
✨ **Result:** Cleaner and less redundant route handler functions.

---
*PR created automatically by Jules for task [9367906745102551864](https://jules.google.com/task/9367906745102551864) started by @ljen*