### PR TITLE
🧹 [code health improvement] Remove duplicate test investigation comment

### DIFF
--- a/evu/tests/arq7_integration_test.rs
+++ b/evu/tests/arq7_integration_test.rs
@@ -220,8 +220,6 @@ fn test_arq7_show_folder_versions_encrypted_found() {
         .success()
         .stdout(predicate::str::contains("Versions for folder: /Users/developer/Projects/2024-12-arq-decryption/arq_backup_source/subfolder"))
         .stdout(predicate::str::contains("Record Timestamp:"))
-        // TODO: Investigate why this shows ~2. JSON and debug log for node.contained_files_count show Some(1).
-        // For now, matching observed behavior.
         .stdout(predicate::str::contains("Items: ~2"));
 }
 


### PR DESCRIPTION
🎯 **What:** Removed duplicate `TODO: Investigate why this shows ~2...` comment block in `evu/tests/arq7_integration_test.rs` at line 223.
💡 **Why:** Reduces noise and improves maintainability by removing redundant commentary that's already present at line 178.
✅ **Verification:** Ran test suites in `evu` and `arq` locally to ensure no tests were deleted or affected. Output from tests matched standard master branch results.
✨ **Result:** A cleaner test file.

---
*PR created automatically by Jules for task [798149509125197933](https://jules.google.com/task/798149509125197933) started by @ljen*