### PR TITLE
🧹 [Extract common test logic between node.rs and blob_location.rs]

### DIFF
--- a/arq/src/blob_location.rs
+++ b/arq/src/blob_location.rs
@@ -372,24 +372,8 @@ impl BlobLoc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Cursor, Read};
-
-    struct NonSeekReader {
-        inner: Cursor<Vec<u8>>,
-    }
-
-    impl Read for NonSeekReader {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            self.inner.read(buf)
-        }
-    }
-
-    fn arq_string(value: &str) -> Vec<u8> {
-        let mut bytes = vec![1];
-        bytes.extend_from_slice(&(value.len() as u64).to_be_bytes());
-        bytes.extend_from_slice(value.as_bytes());
-        bytes
-    }
+    use crate::test_utils::{arq_string, NonSeekReader};
+    use std::io::Cursor;
 
     #[test]
     fn parses_official_arq7_binary_blobloc_error_paths() {
@@ -420,7 +404,7 @@ mod tests {
         data.push(1); // is_packed
         data.extend(arq_string("/PLAN/blobpacks/AA/example.pack"));
         data.extend_from_slice(&12u64.to_be_bytes()); // offset
-        // Missing length, stretch_encryption_key, compression_type
+                                                      // Missing length, stretch_encryption_key, compression_type
         let mut cursor = Cursor::new(data);
         assert!(BlobLoc::from_binary_reader(&mut cursor).is_err());
     }

--- a/arq/src/lib.rs
+++ b/arq/src/lib.rs
@@ -49,4 +49,6 @@ pub mod type_utils;
 mod blob;
 mod date;
 mod lz4;
+#[cfg(test)]
+mod test_utils;
 mod utils;

--- a/arq/src/node.rs
+++ b/arq/src/node.rs
@@ -810,24 +810,8 @@ impl Node {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Cursor, Read};
-
-    struct NonSeekReader {
-        inner: Cursor<Vec<u8>>,
-    }
-
-    impl Read for NonSeekReader {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            self.inner.read(buf)
-        }
-    }
-
-    fn arq_string(value: &str) -> Vec<u8> {
-        let mut bytes = vec![1];
-        bytes.extend_from_slice(&(value.len() as u64).to_be_bytes());
-        bytes.extend_from_slice(value.as_bytes());
-        bytes
-    }
+    use crate::test_utils::{arq_string, NonSeekReader};
+    use std::io::Cursor;
 
     fn arq_null_string() -> Vec<u8> {
         vec![0]

--- a/arq/src/test_utils.rs
+++ b/arq/src/test_utils.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+use std::io::{Cursor, Read};
+
+#[cfg(test)]
+pub struct NonSeekReader {
+    pub inner: Cursor<Vec<u8>>,
+}
+
+#[cfg(test)]
+impl Read for NonSeekReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(test)]
+pub fn arq_string(value: &str) -> Vec<u8> {
+    let mut bytes = vec![1];
+    bytes.extend_from_slice(&(value.len() as u64).to_be_bytes());
+    bytes.extend_from_slice(value.as_bytes());
+    bytes
+}


### PR DESCRIPTION
🎯 **What:** Extracted duplicated test utilities (`NonSeekReader` and `arq_string`) found in `arq/src/node.rs` and `arq/src/blob_location.rs` into a new `arq/src/test_utils.rs` module.
💡 **Why:** Having test utilities duplicated across multiple modules increases maintenance burden and violates DRY principles. This refactor centralizes common test structures into a single location, improving readability and maintainability.
✅ **Verification:** Verified by checking formatting (`cargo fmt`), running static analysis (`cargo check`), running the test suites (`cargo test`) for `arq`, `evu`, and `web-ui` crates, and running a successful code review.
✨ **Result:** Test code footprint is reduced, duplication is removed, and common test structures are easily shareable with any other tests in the future without repetition.

---
*PR created automatically by Jules for task [581522823925242668](https://jules.google.com/task/581522823925242668) started by @ljen*