### PR TITLE
🧹 [Code Health] Remove unused variables in node metadata parsing

### DIFF
--- a/arq/src/node.rs
+++ b/arq/src/node.rs
@@ -505,15 +505,13 @@ impl Node {
 
         // Thumbnail and preview SHA1s (Arq5 specific, deprecated)
         if tree_version <= 18 {
-            let _thumbnail_sha1 = reader.read_arq_string()?; // unused
+            reader.read_arq_string()?; // unused thumbnail_sha1
             if tree_version >= 14 {
-                let _is_thumbnail_encryption_key_stretched = reader.read_arq_bool()?;
-                // unused
+                reader.read_arq_bool()?; // unused is_thumbnail_encryption_key_stretched
             }
-            let _preview_sha1 = reader.read_arq_string()?; // unused
+            reader.read_arq_string()?; // unused preview_sha1
             if tree_version >= 14 {
-                let _is_preview_encryption_key_stretched = reader.read_arq_bool()?;
-                // unused
+                reader.read_arq_bool()?; // unused is_preview_encryption_key_stretched
             }
         }
 


### PR DESCRIPTION
🎯 **What:** Removed unused variables (`_thumbnail_sha1`, `_is_thumbnail_encryption_key_stretched`, `_preview_sha1`, `_is_preview_encryption_key_stretched`) from `arq/src/node.rs` and replaced them with expression statements that discard the unwrapped results from `reader.read_arq_string()?` and `reader.read_arq_bool()?`.

💡 **Why:** This improves the maintainability and cleanliness of the code by removing dead bindings that generate warnings (or necessitate explicit ignore prefixes) while safely preserving the side effects (I/O reading) necessary to parse the byte stream correctly.

✅ **Verification:** Verified by compiling the libraries and running `cargo test --lib` within both `arq` and `evu` crates, confirming that no tests were broken and the functionality remains intact. The code changes have also passed automated code review.

✨ **Result:** The parsing block is cleaner and no longer creates unused redundant bindings, without affecting any behavioral logic.

---
*PR created automatically by Jules for task [6697494794938868300](https://jules.google.com/task/6697494794938868300) started by @ljen*