### PR TITLE
🧹 [Code Health] Remove unused _keyset variable in arq7_example.rs

### DIFF
--- a/arq/examples/arq7_example.rs
+++ b/arq/examples/arq7_example.rs
@@ -56,7 +56,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("❌ Keyset files for Arq7 not found!");
         return Ok(());
     }
-    let _keyset = EncryptedKeySet::from_file(keyset_path, backup_passowrd)?;
     // Load the complete backup set
     match BackupSet::from_directory_with_password(backup_set_path, Some(backup_passowrd)) {
         // match BackupSet::from_directory(backup_set_path) {


### PR DESCRIPTION
🎯 **What:** Removed the unused `_keyset` variable assignment and `EncryptedKeySet::from_file` call in `arq/examples/arq7_example.rs`.

💡 **Why:** The variable was assigned but never used, and the keyset is loaded internally anyway by the subsequent `BackupSet::from_directory_with_password` call. Removing it removes dead code and improves readability.

✅ **Verification:** Verified by compiling the `arq` crate with `--examples` and running the full test suite (`cargo check --examples && cargo test`), which all passed successfully.

✨ **Result:** A cleaner code example with removed dead code.

---
*PR created automatically by Jules for task [5794927062294359119](https://jules.google.com/task/5794927062294359119) started by @ljen*