### PR TITLE
🧪 [testing improvement] Add unit tests for format_timestamp_rfc3339 in evu/src/arq7_handler.rs

### DIFF
--- a/evu/src/arq7_handler.rs
+++ b/evu/src/arq7_handler.rs
@@ -1500,4 +1500,40 @@ mod tests {
         // i64::MAX is valid i64 but beyond valid DateTime bounds usually
         assert_eq!(format_epoch_secs(i64::MAX), i64::MAX.to_string());
     }
+
+    #[test]
+    fn test_format_timestamp_rfc3339() {
+        // Standard epoch: 1970-01-01T00:00:00+00:00
+        assert_eq!(format_timestamp_rfc3339(0.0), "1970-01-01T00:00:00+00:00");
+
+        // Positive timestamp without fractions: 2023-01-01T00:00:00+00:00
+        // 1672531200
+        assert_eq!(
+            format_timestamp_rfc3339(1672531200.0),
+            "2023-01-01T00:00:00+00:00"
+        );
+
+        // Positive timestamp with fractional seconds
+        // 1672531200.5
+        assert_eq!(
+            format_timestamp_rfc3339(1672531200.5),
+            "2023-01-01T00:00:00.500+00:00"
+        );
+
+        // Negative timestamp (before 1970)
+        // -31536000 (1969-01-01T00:00:00+00:00)
+        assert_eq!(
+            format_timestamp_rfc3339(-31536000.0),
+            "1969-01-01T00:00:00+00:00"
+        );
+
+        // Extreme out-of-bounds timestamps (fallback to string representation)
+        // chrono::DateTime limits seconds to i64 limits in naive date time but may reject very large f64
+        // Let's test f64::MAX which is definitely out of bounds.
+        assert_eq!(
+            format_timestamp_rfc3339(std::f64::MAX),
+            std::f64::MAX.to_string()
+        );
+    }
 }
+


### PR DESCRIPTION
🎯 **What:** Adds unit tests for the `format_timestamp_rfc3339` function in `evu/src/arq7_handler.rs` to address an untested logic gap.
📊 **Coverage:** Tests handle the standard epoch (0.0), positive timestamps with and without fractional seconds, negative timestamps (before 1970), and extreme out-of-bounds f64 timestamps to verify string fallback behavior.
✨ **Result:** Test coverage for this pure formatting function is now comprehensive, ensuring the correct behavior of timestamp conversions for Arq 7 handling.

---
*PR created automatically by Jules for task [1110549118600327194](https://jules.google.com/task/1110549118600327194) started by @ljen*