### PR TITLE
🧪 [testing improvement] Add missing test for empty file in is_file_encrypted

### DIFF
--- a/arq/src/arq7/utils.rs
+++ b/arq/src/arq7/utils.rs
@@ -311,6 +311,19 @@ mod tests {
     }
 
     #[test]
+    fn test_is_file_encrypted_false_empty_file() {
+        let path = get_temp_path("empty");
+        {
+            let _file = File::create(&path).unwrap();
+        }
+
+        let result = is_file_encrypted(&path).unwrap();
+        assert!(!result);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn test_is_file_encrypted_false_wrong_header() {
         let path = get_temp_path("unencrypted");
         {


### PR DESCRIPTION
🎯 **What:** Added a missing test for the 0-byte empty file edge case in `is_file_encrypted`.
📊 **Coverage:** The test explicitly verifies that passing an empty file correctly results in a `false` evaluation, covering the `Err(_)` match arm for read errors due to insufficient length perfectly.
✨ **Result:** Improved robustness by confirming the 0-byte edge case is caught and handled cleanly.

---
*PR created automatically by Jules for task [6926902464506052835](https://jules.google.com/task/6926902464506052835) started by @ljen*