### PR TITLE
⚡ Refactor `restore_blob_with_sha` to use `PackSet` cache

### DIFF
--- a/arq/examples/arq7_example.rs
+++ b/arq/examples/arq7_example.rs
@@ -266,7 +266,7 @@ fn print_backup_records(backup_set: &BackupSet, backup_set_path: &str) -> Option
 
                             let packset = PackSet::new(&trees_path);
                             let data = match packset.restore_blob_with_sha(&sha, keyset_ref) {
-                                Ok(d) => d.unwrap(),
+                                Ok(d) => d,
                                 Err(e) => {
                                     println!(
                                         "      ❌ Error restoring blob with SHA {}: {}",

--- a/arq/src/packset.rs
+++ b/arq/src/packset.rs
@@ -25,7 +25,6 @@
 //! It also stores an index of the SHA1s contained in the pack as:
 //!
 //! `/<computer_uuid>/packsets/<folder_uuid>-(blobs|trees)/<sha1>.index`
-use crate::arq7::EncryptedKeySet;
 use crate::compression::CompressionType;
 use crate::error::{Error, Result};
 use crate::object_encryption::{calculate_sha1sum, EncryptedObject};
@@ -55,7 +54,7 @@ impl PackSet {
         &self,
         sha: &str,
         keyset: &crate::arq7::EncryptedKeySet,
-    ) -> Result<Option<Vec<u8>>> {
+    ) -> Result<Vec<u8>> {
         let cached_val = {
             let mut cache_lock = self.blob_cache.lock().map_err(|e| crate::error::Error::IoError(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())))?;
             if cache_lock.is_none() {
@@ -99,11 +98,11 @@ impl PackSet {
             let pack = PackObject::new(&mut pack_reader)?;
 
             match pack.data.decrypt(&keyset.encryption_key) {
-                Ok(data) => return Ok(Some(data)),
+                Ok(data) => return Ok(data),
                 Err(e) => return Err(e),
             }
         }
-        Ok(None)
+        Err(Error::InvalidFormat(format!("SHA not found: {}", sha)))
     }
 }
 
@@ -448,48 +447,4 @@ impl PackObject {
         let content = CompressionType::decompress(&decrypted, compression_type)?;
         Ok(content)
     }
-}
-
-pub fn restore_blob_with_sha(path: &Path, sha: &str, keyset: &EncryptedKeySet) -> Result<Vec<u8>> {
-    for entry_result in fs::read_dir(path)? {
-        let entry = entry_result?;
-
-        let fname = entry.file_name();
-        let fname_str = match fname.to_str() {
-            Some(s) => s,
-            None => {
-                continue;
-            }
-        };
-
-        if fname_str.ends_with(".index") {
-            let index_path = entry.path();
-            let mut reader = get_file_reader_for_restore(&index_path).map_err(Error::IoError)?;
-
-            let index = PackIndex::new(&mut reader)?;
-
-            for obj in index.objects {
-                if obj.sha1 == sha {
-                    let pack_path = index_path.with_extension("pack");
-                    if !pack_path.exists() {
-                        continue;
-                    }
-                    let mut pack_reader =
-                        get_file_reader_for_restore(&pack_path).map_err(Error::IoError)?;
-
-                    pack_reader
-                        .seek(SeekFrom::Start(obj.offset as u64))
-                        .map_err(Error::IoError)?;
-
-                    let pack = PackObject::new(&mut pack_reader)?;
-
-                    match pack.data.decrypt(&keyset.encryption_key) {
-                        Ok(data) => return Ok(data),
-                        Err(e) => return Err(e),
-                    }
-                }
-            }
-        }
-    }
-    Err(Error::InvalidFormat(format!("SHA not found: {}", sha)))
 }

--- a/evu/src/recovery.rs
+++ b/evu/src/recovery.rs
@@ -15,6 +15,7 @@ pub struct RestoreOptions<'a> {
     pub absolute_filepath: &'a str,
     pub folder: &'a str,
     pub keyset: &'a EncryptedKeySet,
+    pub packset: &'a packset::PackSet,
 }
 
 pub fn restore_file(
@@ -34,11 +35,12 @@ pub fn restore_file(
     let keyset = EncryptedKeySet::from_master_keys(master_keys.clone())?;
     let head_sha = utils::find_latest_folder_sha(path, computer, folder)?;
 
-    let data = packset::restore_blob_with_sha(&trees_path, &head_sha, &keyset)?;
+    let packset = packset::PackSet::new(&trees_path);
+    let data = packset.restore_blob_with_sha(&head_sha, &keyset)?;
     let commit = Commit::new(Cursor::new(data))?;
 
     let arq_folder = utils::read_arq_folder(path, computer, folder, master_keys.clone())?;
-    let tree_blob = packset::restore_blob_with_sha(&trees_path, &commit.tree_sha1, &keyset)?;
+    let tree_blob = packset.restore_blob_with_sha(&commit.tree_sha1, &keyset)?;
     let tree = tree::Tree::new_arq5(&tree_blob, commit.tree_compression_type)?;
 
     let options = RestoreOptions {
@@ -46,6 +48,7 @@ pub fn restore_file(
         absolute_filepath,
         folder,
         keyset: &keyset,
+        packset: &packset,
     };
 
     restore_file_in_tree(Path::new(&arq_folder.local_path), tree, &options)
@@ -66,8 +69,7 @@ fn restore_file_in_tree(prefix: &Path, tree: tree::Tree, options: &RestoreOption
                 // Passed node as reference
             }
         } else {
-            let data = packset::restore_blob_with_sha(
-                options.path,
+            let data = options.packset.restore_blob_with_sha(
                 &node.data_blob_locs[0].blob_identifier,
                 options.keyset,
             )?; // Changed to data_blob_locs and blob_identifier

--- a/evu/src/tree.rs
+++ b/evu/src/tree.rs
@@ -47,9 +47,11 @@ pub fn show(path: &str, computer: &str, folder: &str) -> Result<()> {
     let arq_folder = utils::read_arq_folder(path, computer, folder, master_keys.clone())?;
     let head_sha = utils::find_latest_folder_sha(path, computer, folder)?;
 
+    let packset = packset::PackSet::new(&trees_path);
+
     render_tree(
         Path::new(&arq_folder.local_path),
-        &trees_path,
+        &packset,
         &head_sha,
         &keyset,
     )
@@ -57,24 +59,24 @@ pub fn show(path: &str, computer: &str, folder: &str) -> Result<()> {
 
 fn render_tree(
     prefix: &std::path::Path,
-    path: &std::path::PathBuf,
+    packset: &packset::PackSet,
     sha: &str,
     keyset: &EncryptedKeySet,
 ) -> Result<()> {
-    let data = packset::restore_blob_with_sha(path, sha, keyset)?;
+    let data = packset.restore_blob_with_sha(sha, keyset)?;
     let commit = Commit::new(Cursor::new(data))?;
     #[cfg(debug_assertions)]
     show_commit(&commit);
 
-    let tree_blob = packset::restore_blob_with_sha(path, &commit.tree_sha1, keyset)?;
+    let tree_blob = packset.restore_blob_with_sha(&commit.tree_sha1, keyset)?;
     let tree = tree::Tree::new_arq5(&tree_blob, commit.tree_compression_type)?;
-    render_internal_tree(prefix, &path, tree, keyset)?;
+    render_internal_tree(prefix, packset, tree, keyset)?;
     Ok(())
 }
 
 fn render_internal_tree(
     prefix: &std::path::Path,
-    path: &PathBuf,
+    packset: &packset::PackSet,
     tr: tree::Tree,
     keyset: &EncryptedKeySet,
 ) -> Result<()> {
@@ -84,8 +86,7 @@ fn render_internal_tree(
                 // Changed data_blob_keys to data_blob_locs
                 continue;
             }
-            let data = packset::restore_blob_with_sha(
-                &path,
+            let data = packset.restore_blob_with_sha(
                 &v.data_blob_locs[0].blob_identifier,
                 &keyset,
             )?; // Changed to data_blob_locs and blob_identifier
@@ -94,7 +95,7 @@ fn render_internal_tree(
                 v.arq5_data_compression_type
                     .unwrap_or(arq::compression::CompressionType::None),
             )?; // Changed to arq5_data_compression_type
-            render_internal_tree(prefix.join(k).as_path(), &path, tree, &keyset)?;
+            render_internal_tree(prefix.join(k).as_path(), packset, tree, &keyset)?;
         } else {
             println!("{}", prefix.join(k).as_os_str().to_string_lossy());
         }


### PR DESCRIPTION
💡 **What:** Eliminated the standalone `pub fn restore_blob_with_sha` function in `arq/src/packset.rs` which inefficiently performed O(N) disk scans for `.index` files on every call. Modified `evu/src/recovery.rs` and `evu/src/tree.rs` to instantiate and pass down the `PackSet` structure, which has a built-in `Mutex<HashMap>` blob index cache. Also updated the return signature of the struct's method to seamlessly match the old free function.

🎯 **Why:** To eliminate redundant parsing and O(N) disk I/O when restoring blobs, particularly when recovering entire folders or trees. The `PackSet` struct was designed for this exact purpose, but wasn't being utilized correctly during granular blob restoration. 

📊 **Measured Improvement:** Replaced O(N * M) disk scans with an O(N) single-pass caching initialization where `N` is the number of index files and `M` is the number of blobs being restored. I was unable to show a direct benchmark speedup via a test file here, but theoretically and functionally, reading the directory structure and parsing indexes once into a HashMap is vastly superior to doing it for every single blob restored in a tree traversal.

---
*PR created automatically by Jules for task [1619215891964418535](https://jules.google.com/task/1619215891964418535) started by @ljen*