### PR TITLE
🧪 [testing improvement] Add test for Commit::new parent commit count bounds check

### DIFF
--- a/arq/src/commit.rs
+++ b/arq/src/commit.rs
@@ -197,4 +197,24 @@ mod tests {
         let short_array = [0u8; 5];
         assert!(!Commit::is_commit(&short_array));
     }
+
+    #[test]
+    fn test_commit_invalid_num_parents() {
+        use std::io::Cursor;
+        use crate::error::Error;
+
+        let mut data = vec![];
+        data.extend_from_slice(b"CommitV012");
+        data.push(0); // author not present
+        data.push(0); // comment not present
+        data.extend_from_slice(&2u64.to_be_bytes()); // num_parent_commits = 2
+
+        let reader = Cursor::new(data);
+        let result = Commit::new(reader);
+
+        assert!(matches!(
+            result,
+            Err(Error::InvalidFormat(msg)) if msg == "Expected 0 or 1 parent commits, got 2"
+        ));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing test coverage for the upper bounds check on `num_parent_commits` in `Commit::new`. The logic expects 0 or 1, and rejects >1.

📊 **Coverage:** A new test now explicitly covers the scenario where `num_parent_commits` is parsed as 2 from the binary stream.

✨ **Result:** Test coverage improved, preventing regressions for this edge case bounds check.

---
*PR created automatically by Jules for task [9306154283242158543](https://jules.google.com/task/9306154283242158543) started by @ljen*