### PR TITLE
🧪 Add test for invalid commit header error path

### DIFF
--- a/arq/src/commit.rs
+++ b/arq/src/commit.rs
@@ -185,6 +185,7 @@ impl Commit {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     #[test]
     fn test_is_commit() {
@@ -196,5 +197,16 @@ mod tests {
 
         let short_array = [0u8; 5];
         assert!(!Commit::is_commit(&short_array));
+    }
+
+    #[test]
+    fn test_new_invalid_header() {
+        let invalid_commit = b"CommixV012someotherdata";
+        let reader = Cursor::new(invalid_commit);
+        let result = Commit::new(reader);
+        assert!(
+            matches!(result, Err(crate::error::Error::InvalidFormat(msg)) if msg == "Invalid commit header: expected 'CommitV'"),
+            "Expected InvalidFormat error with specific message"
+        );
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the `InvalidFormat` error path in `Commit::new` (when the provided binary data does not start with the 'CommitV' magic bytes) was missing coverage.

📊 **Coverage:** A new unit test `test_new_invalid_header` was added to `arq/src/commit.rs`. It passes a malformed stream (`b"CommixV..."`) and verifies that the function correctly yields an `Err` containing the `Error::InvalidFormat` variant with the exact message `"Invalid commit header: expected 'CommitV'"`.

✨ **Result:** The `Commit::new` constructor error handling is now fully verified against invalid payload headers, improving test coverage and providing a safety net against regressions in binary format parsing logic.

---
*PR created automatically by Jules for task [6633054090496858354](https://jules.google.com/task/6633054090496858354) started by @ljen*