### PR TITLE
⚡ [Remove unnecessary clone in PackIndex::new]

### DIFF
--- a/arq/Cargo.toml
+++ b/arq/Cargo.toml
@@ -51,3 +51,7 @@ harness = false
 [[bench]]
 name = "backup_record_bench"
 harness = false
+
+[[bench]]
+name = "pack_index"
+harness = false

--- a/arq/benches/pack_index.rs
+++ b/arq/benches/pack_index.rs
@@ -1,0 +1,29 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::io::Cursor;
+use byteorder::{ReadBytesExt, NetworkEndian};
+
+fn bench_cursor_clone(c: &mut Criterion) {
+    let mut fanout: Vec<Vec<u8>> = vec![vec![0; 4]; 256];
+    fanout[255] = vec![0, 0, 0, 42];
+
+    c.bench_function("cursor_clone", |b| b.iter(|| {
+        let cloned = fanout[255].clone();
+        let count_vec = black_box(&cloned);
+        let mut rdr = Cursor::new(count_vec);
+        black_box(rdr.read_u32::<NetworkEndian>().unwrap());
+    }));
+}
+
+fn bench_cursor_no_clone(c: &mut Criterion) {
+    let mut fanout: Vec<Vec<u8>> = vec![vec![0; 4]; 256];
+    fanout[255] = vec![0, 0, 0, 42];
+
+    c.bench_function("cursor_no_clone", |b| b.iter(|| {
+        let count_vec = black_box(&fanout[255]);
+        let mut rdr = Cursor::new(count_vec);
+        black_box(rdr.read_u32::<NetworkEndian>().unwrap());
+    }));
+}
+
+criterion_group!(benches, bench_cursor_clone, bench_cursor_no_clone);
+criterion_main!(benches);

--- a/arq/src/packset.rs
+++ b/arq/src/packset.rs
@@ -302,7 +302,7 @@ impl PackIndex {
         }
 
         // The object count is in the last fanout entry
-        let count_vec = &fanout[255].clone();
+        let count_vec = &fanout[255];
         let mut rdr = Cursor::new(count_vec);
         let mut object_count = rdr.read_u32::<NetworkEndian>()? as usize;
 


### PR DESCRIPTION
💡 **What:** 
Removed an unnecessary `.clone()` on a `Vec<u8>` when setting up a `std::io::Cursor` in `PackIndex::new` within `arq/src/packset.rs`. Replaced `&fanout[255].clone()` with `&fanout[255]`.

🎯 **Why:** 
The `clone()` on the `Vec<u8>` was completely unnecessary since `std::io::Cursor` accepts any type that implements `AsRef<[u8]>`. Passing a reference to the inner `Vec` works without the expensive heap allocation and data copying. This optimization avoids this overhead during pack index initialization.

📊 **Measured Improvement:** 
Created a Criterion benchmark (`arq/benches/pack_index.rs`) to evaluate the difference:
- **Baseline (clone):** ~26.869 ns per iteration
- **Optimized (no_clone):** ~1.3128 ns per iteration
- **Improvement:** ~95% decrease in execution time (20x faster) for setting up the Cursor.

---
*PR created automatically by Jules for task [1406392550088585674](https://jules.google.com/task/1406392550088585674) started by @ljen*