### PR TITLE
🧹 Simplify restore_all_folder_versions via refactoring

### DIFF
--- a/evu/benches/recovery_benchmark.rs
+++ b/evu/benches/recovery_benchmark.rs
@@ -33,7 +33,9 @@ fn benchmark_read_dir_uncached(c: &mut Criterion) {
                     if fname.ends_with(".index") {
                         matches += 1;
                         // simulate parse overhead (approximate)
-                        for _ in 0..1000 { black_box(1); }
+                        for _ in 0..1000 {
+                            black_box(1);
+                        }
                     }
                 }
             }
@@ -56,7 +58,9 @@ fn benchmark_read_dir_cached(c: &mut Criterion) {
                 if fname.ends_with(".index") {
                     cached_entries.push(fname);
                     // simulate parse overhead once
-                    for _ in 0..1000 { black_box(1); }
+                    for _ in 0..1000 {
+                        black_box(1);
+                    }
                 }
             }
 

--- a/evu/src/arq7_handler.rs
+++ b/evu/src/arq7_handler.rs
@@ -1134,15 +1134,7 @@ pub fn restore_all_folder_versions(
     let backup_set = load_backup_set(backup_set_path)?;
     let keyset = backup_set.encryption_keyset();
 
-    if !destination_root.exists() {
-        std::fs::create_dir_all(destination_root)?;
-    }
-    if !destination_root.is_dir() {
-        return Err(Error::Generic(format!(
-            "Destination root '{}' is not a directory.",
-            destination_root.display()
-        )));
-    }
+    ensure_destination_directory(destination_root)?;
 
     println!(
         "Restoring all versions of folder '{}' to root '{}'",
@@ -1155,6 +1147,59 @@ pub fn restore_all_folder_versions(
         .filter(|s| !s.is_empty())
         .collect();
 
+    let records_to_process = collect_arq7_records(&backup_set);
+
+    let versions_restored_count = std::sync::atomic::AtomicUsize::new(0);
+
+    records_to_process.into_par_iter().try_for_each(
+        |(folder_uuid, arq7_record, timestamp_str)| -> Result<()> {
+            process_folder_version_record(
+                folder_uuid,
+                arq7_record,
+                &timestamp_str,
+                folder_path_in_backup,
+                &path_parts,
+                &backup_set,
+                backup_set_path,
+                keyset,
+                destination_root,
+                &versions_restored_count,
+            )
+        },
+    )?;
+
+    let final_count = versions_restored_count.load(std::sync::atomic::Ordering::Relaxed);
+    if final_count == 0 {
+        println!(
+            "No versions of folder '{}' found to restore.",
+            folder_path_in_backup
+        );
+    } else {
+        println!(
+            "Finished restoring {} versions of folder '{}'.",
+            final_count, folder_path_in_backup
+        );
+    }
+
+    Ok(())
+}
+
+fn ensure_destination_directory(destination_root: &Path) -> Result<()> {
+    if !destination_root.exists() {
+        std::fs::create_dir_all(destination_root)?;
+    }
+    if !destination_root.is_dir() {
+        return Err(Error::Generic(format!(
+            "Destination root '{}' is not a directory.",
+            destination_root.display()
+        )));
+    }
+    Ok(())
+}
+
+fn collect_arq7_records<'a>(
+    backup_set: &'a BackupSet,
+) -> Vec<(&'a String, &'a arq::arq7::Arq7BackupRecord, String)> {
     let mut records_to_process = Vec::new();
     let mut ts_idx = 0;
     for (folder_uuid, gen_records_vec) in &backup_set.backup_records {
@@ -1176,62 +1221,55 @@ pub fn restore_all_folder_versions(
             }
         }
     }
+    records_to_process
+}
 
-    let versions_restored_count = std::sync::atomic::AtomicUsize::new(0);
+fn process_folder_version_record(
+    folder_uuid: &str,
+    arq7_record: &arq::arq7::Arq7BackupRecord,
+    timestamp_str: &str,
+    folder_path_in_backup: &str,
+    path_parts: &[&str],
+    backup_set: &BackupSet,
+    backup_set_path: &Path,
+    keyset: Option<&EncryptedKeySet>,
+    destination_root: &Path,
+    versions_restored_count: &std::sync::atomic::AtomicUsize,
+) -> Result<()> {
+    debug_eprintln!(
+        "DEBUG: restore_all_folder_versions: Arq7 record timestamp: {}",
+        timestamp_str
+    );
+    let record_local_path_str = arq7_record.local_path.as_deref().unwrap_or("");
+    let bf_config_local_path = backup_set
+        .backup_folder_configs
+        .get(folder_uuid)
+        .map(|bf| bf.local_path.as_str());
 
-    records_to_process.into_par_iter().try_for_each(
-        |(folder_uuid, arq7_record, timestamp_str)| -> Result<()> {
-            debug_eprintln!(
-                "DEBUG: restore_all_folder_versions: Arq7 record timestamp: {}",
-                timestamp_str
-            );
-            let record_local_path_str = arq7_record.local_path.as_deref().unwrap_or("");
-            let bf_config_local_path = backup_set
-                .backup_folder_configs
-                .get(folder_uuid)
-                .map(|bf| bf.local_path.as_str());
+    let effective_path_parts = resolve_effective_path_parts(
+        folder_path_in_backup,
+        path_parts,
+        record_local_path_str,
+        bf_config_local_path,
+    );
 
-            let effective_path_parts = resolve_effective_path_parts(
-                folder_path_in_backup,
-                &path_parts,
-                record_local_path_str,
-                bf_config_local_path,
-            );
-
-            if let Ok(Some(target_node_cow)) = find_node_in_record_tree(
-                &arq7_record.node,
-                &effective_path_parts,
-                0,
-                backup_set_path,
-                keyset,
-            ) {
-                restore_version_from_record(
-                    target_node_cow.as_ref(),
-                    &effective_path_parts,
-                    &timestamp_str,
-                    destination_root,
-                    backup_set_path,
-                    keyset,
-                    &versions_restored_count,
-                )?;
-            }
-            Ok(())
-        },
-    )?;
-
-    let final_count = versions_restored_count.load(std::sync::atomic::Ordering::Relaxed);
-    if final_count == 0 {
-        println!(
-            "No versions of folder '{}' found to restore.",
-            folder_path_in_backup
-        );
-    } else {
-        println!(
-            "Finished restoring {} versions of folder '{}'.",
-            final_count, folder_path_in_backup
-        );
+    if let Ok(Some(target_node_cow)) = find_node_in_record_tree(
+        &arq7_record.node,
+        &effective_path_parts,
+        0,
+        backup_set_path,
+        keyset,
+    ) {
+        restore_version_from_record(
+            target_node_cow.as_ref(),
+            &effective_path_parts,
+            timestamp_str,
+            destination_root,
+            backup_set_path,
+            keyset,
+            versions_restored_count,
+        )?;
     }
-
     Ok(())
 }
 
@@ -1536,4 +1574,3 @@ mod tests {
         );
     }
 }
-

--- a/evu/src/main.rs
+++ b/evu/src/main.rs
@@ -23,9 +23,15 @@ fn main() -> Result<(), evu::error::Error> {
 fn get_computer_uuid(global_path: &Path) -> Result<&str, evu::error::Error> {
     global_path
         .file_name()
-        .ok_or_else(|| evu::error::Error::CliInputError("Invalid path: missing filename".to_string()))?
+        .ok_or_else(|| {
+            evu::error::Error::CliInputError("Invalid path: missing filename".to_string())
+        })?
         .to_str()
-        .ok_or_else(|| evu::error::Error::CliInputError("Invalid path: filename is not valid UTF-8".to_string()))
+        .ok_or_else(|| {
+            evu::error::Error::CliInputError(
+                "Invalid path: filename is not valid UTF-8".to_string(),
+            )
+        })
 }
 
 fn handle_show(
@@ -86,9 +92,7 @@ fn handle_restore(
                 )
             })?;
             let filepath = cmd.value_of("FILEPATH").ok_or_else(|| {
-                evu::error::Error::CliInputError(
-                    "Arq 5 restore requires <FILEPATH>".to_string(),
-                )
+                evu::error::Error::CliInputError("Arq 5 restore requires <FILEPATH>".to_string())
             })?;
             evu::recovery::restore_file(global_path_str, computer_uuid, folder, filepath)?
         }
@@ -98,9 +102,7 @@ fn handle_restore(
                     evu::error::Error::CliInputError("Missing --record argument".to_string())
                 })?;
                 let dest_str = sub_matches.value_of("destination").ok_or_else(|| {
-                    evu::error::Error::CliInputError(
-                        "Missing --destination argument".to_string(),
-                    )
+                    evu::error::Error::CliInputError("Missing --destination argument".to_string())
                 })?;
                 evu::arq7_handler::restore_full_record(
                     global_path,
@@ -116,9 +118,7 @@ fn handle_restore(
                     evu::error::Error::CliInputError("Missing --file argument".to_string())
                 })?;
                 let dest_str = sub_matches.value_of("destination").ok_or_else(|| {
-                    evu::error::Error::CliInputError(
-                        "Missing --destination argument".to_string(),
-                    )
+                    evu::error::Error::CliInputError("Missing --destination argument".to_string())
                 })?;
                 evu::arq7_handler::restore_specific_file_from_record(
                     global_path,
@@ -135,9 +135,7 @@ fn handle_restore(
                     evu::error::Error::CliInputError("Missing --folder argument".to_string())
                 })?;
                 let dest_str = sub_matches.value_of("destination").ok_or_else(|| {
-                    evu::error::Error::CliInputError(
-                        "Missing --destination argument".to_string(),
-                    )
+                    evu::error::Error::CliInputError("Missing --destination argument".to_string())
                 })?;
                 evu::arq7_handler::restore_specific_folder_from_record(
                     global_path,
@@ -150,12 +148,11 @@ fn handle_restore(
                 let folder_path = sub_matches.value_of("folder").ok_or_else(|| {
                     evu::error::Error::CliInputError("Missing --folder argument".to_string())
                 })?;
-                let dest_root_str =
-                    sub_matches.value_of("destination-root").ok_or_else(|| {
-                        evu::error::Error::CliInputError(
-                            "Missing --destination-root argument".to_string(),
-                        )
-                    })?;
+                let dest_root_str = sub_matches.value_of("destination-root").ok_or_else(|| {
+                    evu::error::Error::CliInputError(
+                        "Missing --destination-root argument".to_string(),
+                    )
+                })?;
                 evu::arq7_handler::restore_all_folder_versions(
                     global_path,
                     folder_path,

--- a/evu/src/recovery.rs
+++ b/evu/src/recovery.rs
@@ -79,10 +79,9 @@ fn restore_file_in_tree(
                 // Passed node as reference
             }
         } else {
-            let data = options.packset.restore_blob_with_sha(
-                &node.data_blob_locs[0].blob_identifier,
-                options.keyset,
-            )?; // Changed to data_blob_locs and blob_identifier
+            let data = options
+                .packset
+                .restore_blob_with_sha(&node.data_blob_locs[0].blob_identifier, options.keyset)?; // Changed to data_blob_locs and blob_identifier
             let inner_tree = tree::Tree::new_arq5(
                 &data,
                 node.arq5_data_compression_type

--- a/evu/src/tree.rs
+++ b/evu/src/tree.rs
@@ -86,10 +86,8 @@ fn render_internal_tree(
                 // Changed data_blob_keys to data_blob_locs
                 continue;
             }
-            let data = packset.restore_blob_with_sha(
-                &v.data_blob_locs[0].blob_identifier,
-                &keyset,
-            )?; // Changed to data_blob_locs and blob_identifier
+            let data =
+                packset.restore_blob_with_sha(&v.data_blob_locs[0].blob_identifier, &keyset)?; // Changed to data_blob_locs and blob_identifier
             let tree = tree::Tree::new_arq5(
                 &data,
                 v.arq5_data_compression_type

--- a/evu/tests/arq7_integration_test.rs
+++ b/evu/tests/arq7_integration_test.rs
@@ -229,9 +229,7 @@ fn test_arq7_show_folder_versions_not_found() {
         .arg(ARQ7_UNENCRYPTED_PATH)
         .arg("folder-versions")
         .arg("--folder")
-        .arg(
-            "/Users/ljensen/Projects/2024-12-arq-decryption/arq_backup_source/nonexistentfolder",
-        );
+        .arg("/Users/ljensen/Projects/2024-12-arq-decryption/arq_backup_source/nonexistentfolder");
 
     cmd.assert()
         .success() // Command itself succeeds


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Simplified the overly complex `restore_all_folder_versions` function in `evu/src/arq7_handler.rs` by extracting logical blocks into separate helper functions (`ensure_destination_directory`, `collect_arq7_records`, and `process_folder_version_record`).

💡 **Why:** How this improves maintainability
The original function contained multiple responsibilities (setup, validation, data transformation, parallel execution logic). Isolating these components makes the function more readable, testable, and easier to follow at a high level.

✅ **Verification:** How you confirmed the change is safe
- Preserved existing parameter references and borrow semantics (via `Cow` and explicit lifetime bounds `<'a>`).
- Successfully compiled and passed existing tests in `cargo test arq7_handler`.
- Code review explicitly confirmed that the refactoring strictly maintained data flow and parallel execution constraints (`Sync` in Rayon).

✨ **Result:** The improvement achieved
A significantly cleaner `restore_all_folder_versions` root function that delegates well-named helper routines, promoting robust code quality.

---
*PR created automatically by Jules for task [10359503006505072711](https://jules.google.com/task/10359503006505072711) started by @ljen*