### PR TITLE
🧹 [Code Health] Fix deprecated string error formatting in IoError

### DIFF
--- a/arq/src/packset.rs
+++ b/arq/src/packset.rs
@@ -56,10 +56,10 @@ impl PackSet {
         keyset: &crate::arq7::EncryptedKeySet,
     ) -> Result<Vec<u8>> {
         let cached_val = {
-            let mut cache_lock = self.blob_cache.lock().map_err(|e| {
+            let mut cache_lock = self.blob_cache.lock().map_err(|_e| {
                 crate::error::Error::IoError(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    e.to_string(),
+                    "blob_cache lock poisoned",
                 ))
             })?;
             if cache_lock.is_none() {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the use of deprecated string error formatting inside `IoError` mapping. `e.to_string()` was being used for a `PoisonError` from a mutex lock.
💡 **Why:** This improves code health by avoiding an unnecessary runtime heap allocation (String) and by replacing it with a context-aware static string `&'static str` literal that implements `Into<Box<dyn Error + Send + Sync>>` seamlessly for `io::Error`.
✅ **Verification:** Verified by compiling and running all unit tests in the `arq` crate (`cargo check` and `cargo test`). No new errors or regressions were introduced.
✨ **Result:** A safer, cleaner error handling routine without dynamic allocation stringification.

---
*PR created automatically by Jules for task [15419935885510822134](https://jules.google.com/task/15419935885510822134) started by @ljen*